### PR TITLE
LAFE-29: Verify CRM Defaults

### DIFF
--- a/ansible/roles/test/tasks/crm.yml
+++ b/ansible/roles/test/tasks/crm.yml
@@ -4,7 +4,7 @@
      when: (testbed_type is not defined)
 
    - fail: msg="Invalid testbed_type value '{{testbed_type}}'"
-     when: testbed_type not in ['t0-8', 't1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116']
+     when: testbed_type not in ['t1-8', 't0-8', 't1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116']
 
    - set_fact: crm_intf="{{minigraph_interfaces[0].attachto}}"
                crm_intf1="{{minigraph_interfaces[2].attachto}}"

--- a/ansible/roles/test/tasks/crm.yml
+++ b/ansible/roles/test/tasks/crm.yml
@@ -4,7 +4,7 @@
      when: (testbed_type is not defined)
 
    - fail: msg="Invalid testbed_type value '{{testbed_type}}'"
-     when: testbed_type not in ['t1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116']
+     when: testbed_type not in ['t0-8', 't1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116']
 
    - set_fact: crm_intf="{{minigraph_interfaces[0].attachto}}"
                crm_intf1="{{minigraph_interfaces[2].attachto}}"
@@ -17,6 +17,9 @@
    - set_fact:
         ansible_date_time: "{{ansible_date_time}}"
 
+   - name: Run test case "CRM verify defaults"
+     include: roles/test/tasks/crm/crm_test_verify_defaults.yml
+  
    - name: Set polling interval
      command: crm config polling interval 1
 

--- a/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
@@ -1,10 +1,10 @@
 - block:
 
     - name: Verify Polling Defaults
-      shell: crm show summary |grep -v ^$|awk '{if($3!=300){exit 1}}'
+      shell: crm show summary |awk '/^$/ {next}{if($3!=300){exit 1}}'
 
     - name: Verify Default min thresholds
-      shell: crm show thresholds all|tail +5|grep -v ^$|awk '{if($3!=70){exit 1}}'
+      shell: crm show thresholds all|tail +5|awk '/^$/ {next}{if($3!=70){exit 1}}'
 
     - name: Verify Default max thresholds
-      shell: crm show thresholds all|tail +5|grep -v ^$|awk '{if($4!=85){exit 1}}'
+      shell: crm show thresholds all|tail +5|awk '/^$/ {next}{if($4!=85){exit 1}}'

--- a/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
@@ -1,10 +1,10 @@
 - block:
 
     - name: Verify Polling Defaults
-      shell: crm show summary |awk '/^$/ {next}{if($3!=300){exit 1}}'
+      shell: crm show summary | awk '/^$/ {next}{if($3!=300){exit 1}}'
 
     - name: Verify Default min thresholds
-      shell: crm show thresholds all|tail +5|awk '/^$/ {next}{if($3!=70){exit 1}}'
+      shell: crm show thresholds all | awk '/^$/ {next} NR>4 {if($3!=70){exit 1}}'
 
     - name: Verify Default max thresholds
-      shell: crm show thresholds all|tail +5|awk '/^$/ {next}{if($4!=85){exit 1}}'
+      shell: crm show thresholds all | awk '/^$/ {next} NR>4 {if($4!=85){exit 1}}'

--- a/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
+++ b/ansible/roles/test/tasks/crm/crm_test_verify_defaults.yml
@@ -1,0 +1,10 @@
+- block:
+
+    - name: Verify Polling Defaults
+      shell: crm show summary |grep -v ^$|awk '{if($3!=300){exit 1}}'
+
+    - name: Verify Default min thresholds
+      shell: crm show thresholds all|tail +5|grep -v ^$|awk '{if($3!=70){exit 1}}'
+
+    - name: Verify Default max thresholds
+      shell: crm show thresholds all|tail +5|grep -v ^$|awk '{if($4!=85){exit 1}}'

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -213,7 +213,7 @@ testcases:
 
     crm:
       filename: crm.yml
-      topologies: [t0-8, t1, t1-lag, t0, t0-56, t0-64, t0-116]
+      topologies: [t1-8, t0-8, t1, t1-lag, t0, t0-56, t0-64, t0-116]
 
     dip_sip:
       filename: dip_sip.yml

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -213,7 +213,7 @@ testcases:
 
     crm:
       filename: crm.yml
-      topologies: [t1, t1-lag, t0, t0-56, t0-64, t0-116]
+      topologies: [t0-8, t1, t1-lag, t0, t0-56, t0-64, t0-116]
 
     dip_sip:
       filename: dip_sip.yml
@@ -243,4 +243,3 @@ testcases:
       topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, ptf32, ptf64]
       required_vars:
           testbed_type:
-


### PR DESCRIPTION
Verify the CRM defaults for crm polling and crm thresholds.

Default polling interval should be set to 5 minutes.
Default HIGH threshold should be set to 85%.
Default LOW threshold should be set to 70%.

Using command: `crm show summary` to find the polling interval
Using command: `crm show thresholds all` to find the high/low thresholds