### PR TITLE
LAFE-56: Test portstat command with/without clear counter file

### DIFF
--- a/ansible/roles/test/tasks/test_portstat.yml
+++ b/ansible/roles/test/tasks/test_portstat.yml
@@ -3,21 +3,41 @@
   - name: Clear all saved stats prior to tests
     shell: portstat -D || true
 
-  - name: Test portstat clear and save stats
-    shell: portstat -c -t test
+  - name: Test portstat clear
+    shell: portstat -c
 
   - name: Test portstat json output
     shell: portstat -j | python -m json.tool
 
   - name: Test portstat raw output
-    shell: porstat -r
+    shell: portstat -r
 
-  - name: Test portstat all stat counters
+  - name: Test portstat all
     shell: portstat -a
 
   - name: Test portstat period
     shell: portstat -p 30
+
+  - name: Test portstat clear and save stats
+    shell: portstat -c -t test
+
+  - name: Test portstat json output
+    shell: portstat -j -t test | python -m json.tool
+
+  - name: Test portstat raw output
+    shell: porstat -r -t test
+
+  - name: Test portstat all stat counters
+    shell: portstat -a -t test
+
+  - name: Test portstat period
+    shell: portstat -p 30 -t test
+
+  - name: Test deleting counter
+    shell: portstat -d -t test
   
   always:
   - name: Clear and reset counters
     shell: portstat -D
+  
+  ignore_errors: true

--- a/ansible/roles/test/tasks/test_portstat.yml
+++ b/ansible/roles/test/tasks/test_portstat.yml
@@ -1,0 +1,23 @@
+- block:
+
+  - name: Clear all saved stats prior to tests
+    shell: portstat -D || true
+
+  - name: Test portstat clear and save stats
+    shell: portstat -c -t test
+
+  - name: Test portstat json output
+    shell: portstat -j | python -m json.tool
+
+  - name: Test portstat raw output
+    shell: porstat -r
+
+  - name: Test portstat all stat counters
+    shell: portstat -a
+
+  - name: Test portstat period
+    shell: portstat -p 30
+  
+  always:
+  - name: Clear and reset counters
+    shell: portstat -D

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -164,6 +164,10 @@ testcases:
       filename: port_toggle.yml
       topologies: [t0, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    portstat:
+      filename: test_portstat.yml
+      topologies: [t0-8, t1-8]
+      
     qos:
       filename: qos.yml
       topologies: [ptf32, ptf64]


### PR DESCRIPTION
This tests the portstat command and all of it's outputs with and without the clear counter file.
`testcase_name=portstat`