### PR TITLE
LAFE-60: validate show CLI commands

### DIFF
--- a/ansible/roles/test/tasks/test_sonic_show_cli.yml
+++ b/ansible/roles/test/tasks/test_sonic_show_cli.yml
@@ -1,0 +1,741 @@
+- block:
+
+  - name: Test show (Top Level)
+    shell: show {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - " "
+      - aaa
+      - acl
+      - arp
+      - bgp
+      - clock
+      - ecn
+      - environment
+      - interfaces
+      - ip
+      - ipv6
+      # - line
+      - lldp
+      - logging
+      - mac
+      - mirror_session
+      - mmu
+      - ndp
+      - ntp
+      - pfc
+      - platform
+      - priority-group
+      - processes
+      - queue
+      - reboot-cause
+      - route-map
+      - runningconfiguration
+      - services
+      - startupconfiguration
+      - system-memory
+      - tacacs
+      - techsupport
+      - uptime
+      - users
+      - version
+      - vlan
+      - warm_restart
+      - watermark
+
+  - name: Test show acl
+    shell: show acl {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - rule
+      - table
+
+  - name: Test show bgp
+    shell: show bgp {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - attribute-info
+      - cidr-only
+      - community
+      - community-info
+      - community-list
+      - dampening
+      - detail
+      - filter-list
+      - ipv4
+      - ipv6
+      - json
+      - large-community
+      - large-community-list
+      - memory
+      - neighbors
+      - nexthop
+      - paths
+      - peer-group
+      - prefix-list
+      - "regexp /*/"
+      - route-leak
+      - route-map
+      - statistics
+      - summary
+      - update-groups
+      - view
+      - views
+      - vrf
+      - vrfs
+
+  - name: Test show bgp cidr-only
+    shell: show bgp cidr-only {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+  
+  - name: Test show bgp community 
+    shell: show bgp community {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - accept-own
+      - accept-own-nexthop
+      - blackhole
+      - exact-match
+      - graceful-shutdown
+      - json
+      - llgr-stale
+      - local-AS
+      - no-advertise
+      - no-export
+      - no-llgr
+      - route-filter-translated-v4
+      - route-filter-translated-v6
+      - route-filter-v4
+  
+  - name: Test show bgp community accept-own
+    shell: show bgp community accept-own {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community accept-own-nexthop
+    shell: show bgp community accept-own-nexthop {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+      - route-filter-v6
+
+  - name: Test show bgp community blackhole
+    shell: show bgp community blackhole {{item}}    
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community exact-match
+    shell: show bgp community exact-match {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp community graceful-shutdown
+    shell: show bgp community graceful-shutdown {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+      - no-peer
+
+  - name: Test show bgp community graceful-shutdown
+    shell: show bgp community graceful-shutdown exact-match {{item}}
+    with_items: 
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp community graceful-shutdown no-peer
+    shell: show bgp community graceful-shutdown no-peer {{item}}
+    with_items: 
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+
+  - name: Test show bgp community llgr-stale
+    shell: show bgp community llgr-stale {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community local-AS
+    shell: show bgp community local-AS {{item}}      
+    with_items: 
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community no-advertise
+    shell: show bgp community no-advertise {{item}}      
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community no-export
+    shell: show bgp community no-export {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community no-llgr
+    shell: show bgp community no-llgr {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community route-filter-translated-v4
+    shell: show bgp community route-filter-translated-v4 {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community route-filter-translated-v6
+    shell: show bgp community route-filter-translated-v6 {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp community route-filter-v4
+    shell: show bgp community route-filter-v4 {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - exact-match
+      - json
+
+  - name: Test show bgp dampening
+    shell: show bgp dampening {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - dampened-paths
+      - flap-statistics
+      - parameters
+
+  - name: Test show bgp detail
+    shell: show bgp detail {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"    
+      - json
+
+  - name: Test show bgp ipv4
+    shell: show bgp ipv4 {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - cidr-only
+      - community
+      - community-list
+      - dampening
+      - filter-list
+      - flowspec
+      - json
+      - labeled-unicast
+      - large-community
+      - large-community-list
+      - multicast
+      - neighbors
+      - prefix-list
+      - regexp
+      - route-leak
+      - route-map
+      - statistics
+      - summary
+      - unicast
+      - update-groups
+      - vpn
+
+  - name: Test show bgp ipv6
+    shell: show bgp ipv6 {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - cidr-only
+      - community
+      - community-list
+      - dampening
+      - filter-list
+      - flowspec
+      - json
+      - labeled-unicast
+      - large-community
+      - large-community-list
+      - multicast
+      - neighbors
+      - prefix-list
+      - regexp
+      - route-leak
+      - route-map
+      - statistics
+      - summary
+      - unicast
+      - update-groups
+      - vpn
+
+  - name: Test show bgp l2vpn
+    shell: show bgp l2vpn {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - evpn
+  
+  - name: Test show bgp large-community
+    shell: show bgp large-community {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp martian
+    shell: show bgp martian {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - next-hop
+
+  - name: Test show bgp multicast
+    shell: show bgp multicast {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - paths
+
+  - name: Test show bgp neighbors
+    shell: show bgp neighbors {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp nexthop
+    shell: show bgp nexthop {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - detail
+
+  - name: Test show bgp route-leak
+    shell: show bgp route-leak {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp summary
+    shell: show bgp summary {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show bgp unicast
+    shell: show bgp unicast {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - paths
+
+  - name: Test show bgp update-groups
+    shell: show bgp update-groups {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - advertise-queue
+      - advertised-routes
+      - packet-queue
+      - statistics
+
+  - name: Test show bgp update-groups advertise-queue
+    shell: show bgp update-groups advertise-queue {{item}}  
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"    
+      - advertise-queue
+      - advertised-routes
+      - packet-queue
+
+  - name: Test show bgp update-groups advertised-routes
+    shell: show bgp update-groups advertised-routes {{item}}  
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - advertise-queue
+      - advertised-routes
+      - packet-queue
+
+  - name: Test show bgp update-groups packet-queue
+    shell: show bgp update-groups packet-queue {{item}}  
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - advertise-queue
+      - advertised-routes
+      - packet-queue
+
+  - name: Test show bgp update-groups statistics
+    shell: show bgp update-groups statistics {{item}}  
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - advertise-queue
+      - advertised-routes
+      - packet-queue
+
+  - name: Test show bgp view
+    shell: show bgp view {{item}}
+    with_items: 
+      - "--help"
+      - "-h"
+      - "-?"
+      - all
+
+  - name: Test show bgp vpn
+    shell: show bgp vpn {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - paths
+
+  - name: Test show bgp vrf
+    shell: show bgp vrf {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - all
+
+  - name: Test show bgp vrfs
+    shell: show bgp vrfs {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - json
+
+  - name: Test show interfaces
+    shell: show interfaces {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - counters
+      - description
+      - naming_mode
+      - neighbor
+      - portchannel
+      - status
+      - transceiver
+
+  - name: Test show interfaces neighbor
+    shell: show interfaces neighbor {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - expected
+
+  - name: Test show interfaces transceiver
+    shell: show interfaces transceiver {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - eeprom
+      - lpmode
+      - presence
+
+  - name: Test show ip
+    shell: show ip {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - interfaces
+      - prefix-list
+      - protocol
+      - route
+
+  - name: Test show ip prefix-list
+    shell: show ip prefix-list {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - detail
+      - summary
+
+  - name: Test shopw ip route
+    shell: show ip route {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - babel
+      - bgp
+      - connected
+      - eigrp
+      - isis
+      - json
+      - kernel
+      - nhrp
+      - ospf
+      - rip
+      - sharp
+      - static
+      - summary
+      - supernets-only
+      - table
+      - tag
+      - vnc
+      - vrf
+
+  - name: Test show ipv6
+    shell: show ipv6 {{item}}
+    with_items: 
+      - "--help"
+      - "-h"
+      - "-?"
+      - interfaces
+      - protocol
+      - route
+
+  - name: Test show ipv6 route
+    shell: show ipv6 route {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - babel
+      - bgp
+      - connected
+      - isis
+      - json
+      - kernel
+      - nhrp
+      - ospf6
+      - ripng
+      - sharp
+      - static
+      - summary
+      - table
+      - tag
+      - vnc
+      - vrf
+
+  - name: Test show lldp
+    shell: show lldp {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - neighbors
+      - table
+
+  - name: Test show pfc
+    shell: show pfc {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - counters
+
+  - name: Test shopw platform
+    shell: show platform {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - psustatus
+      - summary
+      - syseeprom
+
+  - name:  Test show priority-group
+    shell: show priority-group {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - persistent-watermark
+      - watermark
+
+  - name: Test show priority-group persistent-watermark
+    shell: show priority-group persistent-watermark {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - headroom
+      - shared
+
+  - name: Test show priority-group watermark
+    shell: show priority-group watermark {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - headroom
+      - shared
+
+  - name: Test show processes
+    shell: show processes {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - cpu
+      - memory
+      - summary
+
+  - name: Test show queue
+    shell: show queue {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - counters
+      - persistent-watermark
+      - watermark
+
+  - name: Test show queue persistent-watermark
+    shell: show queue persistent-watermark {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - multicast
+      - unicast
+
+  - name: Test show queue watermark
+    shell: show queue watermark {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - multicast
+      - unicast
+
+  - name: Test show runningconfiguration
+    shell: show runningconfiguration {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - all
+      - bgp
+      - interfaces
+      - ntp
+      - snmp
+  
+  - name: Test show startupconfiguration
+    shell: show startupconfiguration {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - bgp
+  
+  - name: Test show vlan
+    shell: show vlan {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - brief
+      - config
+  
+  - name: Test show warm_restart
+    shell: show warm_restart {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - config
+      - state
+  
+  - name: Test show watermark
+    shell: show watermark {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - telemetry
+
+  - name: Test show watermark telemetry
+    shell: show watermark telemetry {{item}}
+    with_items:
+      - "--help"
+      - "-h"
+      - "-?"
+      - interval
+      
+  ignore_errors: yes

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -204,6 +204,10 @@ testcases:
       filename: syslog.yml
       topologies: [t0-8, t1-8, t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    sonic_cli:
+      filename: test_sonic_show_cli.yml
+      topologies: [t0-8, t1-8]
+      
     vlan:
       filename: vlantb.yml
       topologies: [t0, t0-16, t0-116]


### PR DESCRIPTION
Tests all `show` commands for the Sonic CLI. exercising down the tree and validating that -h/-help work as well.

`testcase=sonic_cli`