### PR TITLE
Updating testcases to work with t0-8 and t1-8 topologies

### DIFF
--- a/ansible/roles/test/tasks/crm.yml
+++ b/ansible/roles/test/tasks/crm.yml
@@ -4,11 +4,11 @@
      when: (testbed_type is not defined)
 
    - fail: msg="Invalid testbed_type value '{{testbed_type}}'"
-     when: testbed_type not in ['t1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116']
+     when: testbed_type not in ['t1', 't1-lag', 't0', 't0-56', 't0-64', 't0-116', 't0-8', 't1-8']
 
    - set_fact: crm_intf="{{minigraph_interfaces[0].attachto}}"
                crm_intf1="{{minigraph_interfaces[2].attachto}}"
-     when: testbed_type == "t1"
+     when: testbed_type in ['t1', 't0-8', 't1-8']
 
    - set_fact: crm_intf="{{minigraph_portchannel_interfaces[0].attachto}}"
                crm_intf1="{{minigraph_portchannel_interfaces[2].attachto}}"

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -213,7 +213,7 @@ testcases:
 
     crm:
       filename: crm.yml
-      topologies: [t1, t1-lag, t0, t0-56, t0-64, t0-116]
+      topologies: [t0-8, t1-8, t1, t1-lag, t0, t0-56, t0-64, t0-116]
 
     dip_sip:
       filename: dip_sip.yml


### PR DESCRIPTION
changes needed to support lafe-27-get-crm-counters test.  Changes required to get the existing test base working with the existing crm tests.
