### PR TITLE
Updated script to work with updated ifconfig output

### DIFF
--- a/ansible/roles/test/files/helpers/change_mac.sh
+++ b/ansible/roles/test/files/helpers/change_mac.sh
@@ -2,9 +2,10 @@
 
 for i in $(ifconfig | grep eth | cut -f 1 -d ' ')
 do
-  prefix=$(ifconfig $i | grep HWaddr | cut -c39-53)
-  suffix=$( printf "%02x" ${i##eth})
-  mac=$prefix$suffix  
-  echo $i $mac
-  ifconfig $i hw ether $mac
+  port="${i//:}"
+  prefix=$(ifconfig $port | grep ether | cut -c15-29)
+  suffix=$( printf "%02x" ${port##eth})
+  mac=$prefix$suffix
+  echo $port $mac
+  ifconfig $port hw ether $mac
 done


### PR DESCRIPTION

Old ifconfig output (example from internet)
```
lo        Link encap:Local Loopback 
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:16436  Metric:1
          RX packets:8 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:480 (480.0 b)  TX bytes:480 (480.0 b)
```

Current ifconfig output on the PTF container
```
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9216
        ether ba:0b:a0:6a:c2:00  txqueuelen 1000  (Ethernet)
        RX packets 148058  bytes 14664393 (13.9 MiB)
        RX errors 0  dropped 6517  overruns 0  frame 0
        TX packets 10  bytes 828 (828.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

Updated the sonic-mgmt/ansible/roles/test/files/helpers/change_mac.sh script to work with the updated command output format