### PR TITLE
Add log flood to test

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -178,6 +178,8 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME},lldp_neighbors
 ```
 - Requires switch connected to a VM set testbed
 
+
+
 ##### MAC read test
 ```
 ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} -e testbed_name={TESTBED_NAME} -e testbed_type={TESTBED_TYPE} -e testcase_name=read_mac -e iterations={ITERATIONS} -e image1={IMAGE1} -e image2={IMAGE2}
@@ -197,6 +199,14 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=mtu -e testbed_name={TESTBED_NAME}
 ```
 - Requires switch connected to PTF testbed
+
+##### Log flood test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=log_flood -e testbed_name={TESTBED_NAME} 
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=log_flood -e testbed_name={TESTBED_NAME} -e qty_flood_messages=100
+```
+- Can set optional parameter to adjust the number of log messages to send
+- Default is 10,000 messages
 
 ##### Neighbor Mac test
 ```

--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -178,8 +178,6 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME},lldp_neighbors
 ```
 - Requires switch connected to a VM set testbed
 
-
-
 ##### MAC read test
 ```
 ansible-playbook test_sonic.yml -i inventory --limit {DUT_NAME} -e testbed_name={TESTBED_NAME} -e testbed_type={TESTBED_TYPE} -e testcase_name=read_mac -e iterations={ITERATIONS} -e image1={IMAGE1} -e image2={IMAGE2}

--- a/ansible/roles/test/tasks/log_flood.yml
+++ b/ansible/roles/test/tasks/log_flood.yml
@@ -1,0 +1,62 @@
+# Pull CPU and memory, send a script to create syslogs to the DUT, wait 5 seconds, and make sure device is still within norms
+
+- name: set default value for number of syslog messages
+  set_fact:
+      qty_flood_messages: 10000
+  when: qty_flood_messages is not defined
+
+- name: pull CPU utilization via shell
+  # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grap the CPU line from the second,
+  # subtract 100% - idle, and round down to integer.
+  shell: top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf "%.0f",$1}'
+  register: shell_cpu_usage_before
+  become: yes
+
+- name: get used memory info
+  shell: "show system-memory | grep Mem: | while read name total used everything_else; do echo $used; done"
+  register: used_memory_before
+
+- name: pre test memory values
+  debug:
+    var: used_memory_before.stdout
+
+- name: pre test cpu values
+  debug:
+    var: shell_cpu_usage_before.stdout
+
+- name: Send a script to the remote device
+  script: roles/test/tasks/log_flood/log_flood.sh {{ qty_flood_messages }}
+
+- name: wait 10 seconds for the cpu to calm down
+  pause:
+    seconds: 10
+
+- name: pull CPU utilization via shell
+  # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grap the CPU line from the second,
+  # subtract 100% - idle, and round down to integer.
+  shell: top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf "%.0f",$1}'
+  register: shell_cpu_usage_after
+  become: yes
+
+- name: get used memory info before
+  shell: "show system-memory | grep Mem: | while read name total used everything_else; do echo $used; done"
+  register: used_memory_after
+
+- name: post test memory values
+  debug:
+    var: used_memory_after.stdout
+
+- name: post test cpu values
+  debug:
+    var: shell_cpu_usage_after.stdout
+
+# Arbitrarially picked that if the CPU is 10% 5 seconds after the log flood is done, should fail
+- name: verify cpu usage is not significantly higher than it was before it started
+  assert:
+    that: ({{shell_cpu_usage_after.stdout}} - {{shell_cpu_usage_before.stdout}}) < 10
+
+# Make sure the memory usage doesn't go up too much
+- name: verify memory usage is not significantly higher than it was before it started
+  assert:
+    that: ({{used_memory_after.stdout}} - {{used_memory_before.stdout}}) < 10
+

--- a/ansible/roles/test/tasks/log_flood/log_flood.sh
+++ b/ansible/roles/test/tasks/log_flood/log_flood.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+log_qty=${1:-1000}
+for i in $(seq 1 $log_qty) 
+do
+    logger "Log flood test message $i of $log_qty"
+done
+

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -152,6 +152,10 @@ testcases:
       filename: link_flap.yml
       topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    log_flood:
+      filename: log_flood.yml
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t1]
+
     continuous_link_flap:
       filename: continuous_link_flap.yml
       topologies: [t0, t0-16, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Add log_flood test to the repo
<!--
- added a test that creates a large number of syslog messages and verifies the system CPU and memory do not stay elevated after test completion
- LinkedIn asked us to write this test for them
- Need to have a test server and ability to copy test file onto the DUT
-->

Summary:
No Fixes

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### How did you do it?
Created a new test called log_flood.  I check the CPU and memory of the DUT.  I copy a script to the DUT and execute it.  The script creates the specified number of syslog messaages using the logger command.  Then wait 10 seconds and verify the CPU and Memory usage is approximately close to what it was prior to starting the test.

#### How did you verify/test it?
Using a SeastoneDX010 switch running Sonic software:  SONiC.HEAD.15-23fb00c

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Tested on t1-8 and t0-8 that was provided by LinkedIn but should work on all t0 and t1 topologies.
Both the t0-8 and the t1-8 tests passed

### Documentation 
Added doc update to the tests page for this new test

### Test Output
Below is the test command used and the results of the test for the t0-8 and the t1-8 tests
```
ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=log_flood

lab-ignw-seastone-dut-li1  : ok=56   changed=12   unreachable=0    failed=0   

Monday 12 August 2019  21:22:49 +0000 (0:00:00.085)       0:01:33.361 ********* 
=============================================================================== 
TASK: test : Send a script to the remote device ------------------------ 43.84s
TASK: test : wait 10 seconds for the cpu to calm down ------------------ 10.15s
TASK: test : pull CPU utilization via shell ----------------------------- 5.57s
TASK: test : pull CPU utilization via shell ----------------------------- 5.57s
TASK: test : Verify port channel interfaces are up correctly ------------ 2.10s
TASK: test : validate all interfaces are up after test ------------------ 1.75s
TASK: test : gather system version information -------------------------- 1.49s
TASK: test : Verify port channel interfaces are up correctly ------------ 1.20s
TASK: test : get used memory info before -------------------------------- 1.04s
TASK: test : get used memory info --------------------------------------- 1.03s
TASK: setup ------------------------------------------------------------- 1.02s
TASK: test : Get interface facts ---------------------------------------- 0.96s
TASK: test : validate all interfaces are up ----------------------------- 0.91s
TASK: test : Get interface facts ---------------------------------------- 0.87s
TASK: test : do basic sanity check after each test ---------------------- 0.84s
TASK: test : Get process information in syncd docker -------------------- 0.78s
TASK: test : Get process information in syncd docker -------------------- 0.70s
TASK: test : Verify VLAN interfaces are up correctly -------------------- 0.57s
TASK: test : Gather minigraph facts about the device -------------------- 0.56s
TASK: test : Gather minigraph facts about the device -------------------- 0.54s

```

```
ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=log_flood

"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=52   changed=12   unreachable=0    failed=0   

Monday 12 August 2019  19:06:11 +0000 (0:00:00.076)       0:01:29.049 ********* 
=============================================================================== 
TASK: test : Send a script to the remote device ------------------------ 43.81s
TASK: test : wait 10 seconds for the cpu to calm down ------------------ 10.13s
TASK: test : pull CPU utilization via shell ----------------------------- 5.56s
TASK: test : pull CPU utilization via shell ----------------------------- 5.55s
TASK: test : validate all interfaces are up after test ------------------ 1.73s
TASK: test : gather system version information -------------------------- 1.52s
TASK: setup ------------------------------------------------------------- 1.12s
TASK: test : get used memory info before -------------------------------- 1.07s
TASK: test : get used memory info --------------------------------------- 1.04s
TASK: test : validate all interfaces are up ----------------------------- 0.90s
TASK: test : do basic sanity check after each test ---------------------- 0.81s
TASK: test : Get interface facts ---------------------------------------- 0.79s
TASK: test : Get interface facts ---------------------------------------- 0.78s
TASK: test : Get process information in syncd docker -------------------- 0.76s
TASK: test : Get process information in syncd docker -------------------- 0.68s
TASK: test : Gather minigraph facts about the device -------------------- 0.55s
TASK: test : Gather minigraph facts about the device -------------------- 0.54s
TASK: test : Gathering minigraph facts about the device ----------------- 0.52s
TASK: test : do basic sanity check before each test --------------------- 0.47s
TASK: test : Gathering testbed information ------------------------------ 0.44s"

```
