### PR TITLE
Adding bgp_neighbor test to the repo

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -48,6 +48,13 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ```
 - Requires switch connected to a VM set testbed
 
+#### BGP neighbor test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=bgp_neighbor -e testbed_name={TESTBED_NAME}
+```
+- Test requires that BGP neighbors be established
+
+
 ##### BGP Multipath Relax test
 ```
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=bgp_multipath_relax -e testbed_name={TESTBED_NAME}

--- a/ansible/roles/test/tasks/bgp_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor.yml
@@ -1,4 +1,13 @@
-# Test file to determine BGP neighbor status
+# Test file to verify that the bgp cli commands accurately work
+# Does the following
+#  - Determines all the BGP ipv4 and ipv6 neighbors
+#  - For each neighbor the test does the following
+#     - Shuts down the neighbor
+#     - Confirms the neighbor is down
+#     - Brings up the neighbor
+#     - Confirms the neighbor comes back up
+#
+# Test fails if any neighbors don't go down or come up as expected
 
 # Verify ipv4 operation
 - name: Execute Show Command

--- a/ansible/roles/test/tasks/bgp_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor.yml
@@ -1,0 +1,44 @@
+# Test file to determine BGP neighbor status
+
+# Verify ipv4 operation
+- name: Execute Show Command
+  shell: show bgp ipv4 summary json
+  register: output
+
+- name: convert output to json and extract ipv4 bgp neighbors
+  set_fact:
+    bgp_neighbors: "{{ (output.stdout|from_json).ipv4Unicast.peers }}"
+
+- name: create a list of all the ipv4 bgp neighbors 
+  set_fact:
+    bgp_neighbor_list: "{{ bgp_neighbors.keys() | list }}"
+
+- name: verify ipv4 bgp neighbors are 'Established' or 'Active'
+  assert: { that: "bgp_neighbors[item].state in ['Established', 'Active']" }
+  with_items: "{{ bgp_neighbor_list }}"
+
+- name: call subtask to test each ipv4 neighbor
+  include: roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml neighbor={{ item }}
+  with_items: "{{ bgp_neighbor_list }}"
+
+# Verify ipv6 operation
+- name: Execute Show Command
+  shell: show bgp ipv6 summary json
+  register: output
+
+- name: convert output to json and extract ipv6 bgp neighbors
+  set_fact:
+    bgp_neighbors: "{{ (output.stdout|from_json).ipv6Unicast.peers }}"
+
+- name: create a list of all the ipv6 bgp neighbors
+  set_fact:
+    bgp_neighbor_list: "{{ bgp_neighbors.keys() | list }}"
+
+- name: verify bgp ipv6 neighbors are 'Established' or 'Active'
+  assert: { that: "bgp_neighbors[item].state in ['Established', 'Active']" }
+  with_items: "{{ bgp_neighbor_list }}"
+
+- name: call subtask to test each ipv6 neighbor
+  include: roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml neighbor={{ item }}
+  with_items: "{{ bgp_neighbor_list }}"
+

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
@@ -2,7 +2,7 @@
 - block:
   - name: output variables
     debug:
-      msg: "Exercizing BGP neighbor link: {{ neighbor }}"
+      msg: "Exercising BGP neighbor link: {{ neighbor }}"
 
   - name: shut down neighbor link {{ neighbor }} 
     shell: config bgp shutdown neighbor {{ neighbor }}

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
@@ -1,0 +1,49 @@
+# Subtask to bounce an ipv4 neighbor and verify it comes back
+- block:
+  - name: output variables
+    debug:
+      msg: "Exercizing BGP neighbor link: {{ neighbor }}"
+
+  - name: shut down neighbor link {{ neighbor }} 
+    shell: config bgp shutdown neighbor {{ neighbor }}
+    become: yes
+
+  - name: execute show command
+    shell: show bgp ipv4 summary json
+    register: output
+
+  - name: convert output to json and extract bgp neighbor
+    set_fact:
+      subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv4Unicast.peers }}"
+
+  - name: verify bgp neighbor is 'Idle (Admin)'
+    assert: { that: "subtask_bgp_neighbor[neighbor].state == 'Idle (Admin)'" }
+
+  - name: start up bgp neighbor link {{ neighbor }}
+    shell: config bgp startup neighbor {{ neighbor }}
+    become: yes
+
+  - name: wait for link to come up
+    pause:
+      seconds: 5
+
+  - name: execute show command
+    shell: show bgp ipv4 summary json
+    register: output
+
+  - name: convert output to json and extract bgp neighbor 
+    set_fact:
+      subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv4Unicast.peers }}"
+
+  - name: verify bgp neighbor is 'Established' or 'Active'
+    assert: { that: "subtask_bgp_neighbor[neighbor].state in ['Established', 'Active']" }
+
+- rescue:
+  - name: start up neighbor links due to failed test
+    shell: config bgp startup neighbor {{ neighbor }}
+    become: yes
+
+  - name: output debug message
+    debug:
+      msg: "Starting up link {{ neighbor }} due to failed test"
+

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
@@ -1,0 +1,49 @@
+# Subtask to bounce an ipv6 neighbor and verify it comes back
+- block:
+  - name: output variables
+    debug:
+      msg: "Exercizing BGP neighbor link: {{ neighbor }}"
+
+  - name: shut down neighbor link {{ neighbor }}
+    shell: config bgp shutdown neighbor {{ neighbor }}
+    become: yes
+
+  - name: execute show command
+    shell: show bgp ipv6 summary json
+    register: output
+
+  - name: convert output to json and extract bgp neighbor 
+    set_fact:
+      subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv6Unicast.peers }}"
+
+  - name: verify bgp neighbor is 'Idle (Admin)'
+    assert: { that: "subtask_bgp_neighbor[neighbor].state == 'Idle (Admin)'" }
+
+  - name: start up neighbor links {{ neighbor }}
+    shell: config bgp startup neighbor {{ neighbor }}
+    become: yes
+
+  - name: wait for link to come up
+    pause:
+      seconds: 5 
+
+  - name: execute show command
+    shell: show bgp ipv6 summary json
+    register: output
+
+  - name: convert output to json and extract bgp neighbor 
+    set_fact:
+      subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv6Unicast.peers }}"
+
+  - name: verify bgp neighbor is 'Established'
+    assert: { that: "subtask_bgp_neighbor[neighbor].state in ['Established', 'Active']" }
+
+- rescue:
+  - name: start up neighbor link due to failed test
+    shell: config bgp startup neighbor {{ neighbor }}
+    become: yes
+
+  - name: output debug message
+    debug:
+      msg: "Starting up link {{ neighbor }} due to failed test"
+

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
@@ -2,7 +2,7 @@
 - block:
   - name: output variables
     debug:
-      msg: "Exercizing BGP neighbor link: {{ neighbor }}"
+      msg: "Exercising BGP neighbor link: {{ neighbor }}"
 
   - name: shut down neighbor link {{ neighbor }}
     shell: config bgp shutdown neighbor {{ neighbor }}

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -27,6 +27,10 @@ testcases:
           ptf_host:
           testbed_type:
 
+    bgp_neighbor:
+      filename: bgp_neighbor.yml
+      topologies: [t0, t0-16, t0-56, t0-64, t1]
+
     bgp_speaker:
       filename: bgp_speaker.yml
       topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116]


### PR DESCRIPTION
### Add bgp_neighbor test to the repo

- Test pulls all the bgp_neigbors and uses command line commands to disable then enable them
- Verifies that the link goes down then comes back up
- LinkedIn asked us to write this test for them
- Need to have a test server and ability to copy test file onto the DUT

Summary:
No Fixes

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
#### How did you do it?
Created a new test called bgp_neighbor.  Pull a list of all the bgp neighbors for ipv4 and ipv6.  Iterate through each neighbor and shutting down then enabling the link.  Verify that the link goes down then comes back up.

#### How did you verify/test it?
Using a SeastoneDX010 switch running Sonic software:  SONiC.HEAD.15-23fb00c

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Tested on t1-8 and t0-8 that was provided by LinkedIn but should work on all t0 and t1 topologies.
Both the t0-8 and the t1-8 tests passed

### Documentation 
Added doc update to the tests page for this new test

### Test Output
Below is the test command used and the results of the test for the t0-8 and the t1-8 tests

```
ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=bgp_neighbor

"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=139  changed=41   unreachable=0    failed=0   

Monday 12 August 2019  22:48:20 +0000 (0:00:00.075)       0:02:08.334 ********* 
=============================================================================== 
TASK: test : wait for link to come up ----------------------------------- 5.19s
TASK: test : wait for link to come up ----------------------------------- 5.18s
TASK: test : wait for link to come up ----------------------------------- 5.18s
TASK: test : wait for link to come up ----------------------------------- 5.17s
TASK: test : wait for link to come up ----------------------------------- 5.16s
TASK: test : wait for link to come up ----------------------------------- 5.14s
TASK: test : wait for link to come up ----------------------------------- 5.12s
TASK: test : wait for link to come up ----------------------------------- 5.10s
TASK: test : call subtask to test each ipv6 neighbor -------------------- 4.39s
TASK: test : call subtask to test each ipv4 neighbor -------------------- 3.23s
TASK: test : execute show command --------------------------------------- 2.06s
TASK: test : Verify port channel interfaces are up correctly ------------ 1.98s
TASK: test : execute show command --------------------------------------- 1.95s
TASK: test : execute show command --------------------------------------- 1.94s
TASK: test : execute show command --------------------------------------- 1.94s
TASK: test : execute show command --------------------------------------- 1.92s
TASK: test : execute show command --------------------------------------- 1.91s
TASK: test : execute show command --------------------------------------- 1.91s
TASK: test : execute show command --------------------------------------- 1.80s
TASK: test : execute show command --------------------------------------- 1.78s
```

```
ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=bgp_neighbor

"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=223  changed=73   unreachable=0    failed=0   

Monday 12 August 2019  18:15:02 +0000 (0:00:00.068)       0:03:53.872 ********* 
=============================================================================== 
TASK: test : call subtask to test each ipv6 neighbor ------------------- 14.75s
TASK: test : call subtask to test each ipv4 neighbor -------------------- 6.30s
TASK: test : wait for link to come up ----------------------------------- 5.17s
TASK: test : wait for link to come up ----------------------------------- 5.17s
TASK: test : wait for link to come up ----------------------------------- 5.17s
TASK: test : wait for link to come up ----------------------------------- 5.16s
TASK: test : wait for link to come up ----------------------------------- 5.16s
TASK: test : wait for link to come up ----------------------------------- 5.16s
TASK: test : wait for link to come up ----------------------------------- 5.15s
TASK: test : wait for link to come up ----------------------------------- 5.14s
TASK: test : wait for link to come up ----------------------------------- 5.13s
TASK: test : wait for link to come up ----------------------------------- 5.13s
TASK: test : wait for link to come up ----------------------------------- 5.13s
TASK: test : wait for link to come up ----------------------------------- 5.13s
TASK: test : wait for link to come up ----------------------------------- 5.13s
TASK: test : wait for link to come up ----------------------------------- 5.12s
TASK: test : wait for link to come up ----------------------------------- 5.12s
TASK: test : wait for link to come up ----------------------------------- 5.11s
TASK: test : verify bgp ipv6 neighbors are 'Established' or 'Active' ---- 4.81s
TASK: test : verify ipv4 bgp neighbors are 'Established' or 'Active' ---- 2.97s
```


Signed-Off-by: Joseph Jacobs joej@ignw.io  (my work email address)