### PR TITLE
Lafe 67 update bgp neighbor test

### DIFF
--- a/ansible/roles/test/tasks/bgp_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor.yml
@@ -21,7 +21,7 @@
     - name: Note reason for failure
       debug:
         msg: "The state of all the ipv4 bgp neighbors is not 'Established'.  Fix that before running this test"
-    - name: Force the command to fail after outputing failure message
+    - name: Stop the test here due to pre-condition failure
       assert:
         that: False
 
@@ -50,6 +50,9 @@
     - name: Note reason for failure
       debug:
         msg: "The state of all the ipv6 bgp neighbors is not 'Established'.  Fix that before running this test"
+    - name: Stop the test here due to pre-condition failure
+      assert:
+        that: False
 
 - name: call subtask to test each ipv6 neighbor
   include: roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml neighbor={{ item }}

--- a/ansible/roles/test/tasks/bgp_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor.yml
@@ -13,9 +13,17 @@
   set_fact:
     bgp_neighbor_list: "{{ bgp_neighbors.keys() | list }}"
 
-- name: verify ipv4 bgp neighbors are 'Established' or 'Active'
-  assert: { that: "bgp_neighbors[item].state in ['Established', 'Active']" }
-  with_items: "{{ bgp_neighbor_list }}"
+- block:
+    - name: verify ipv4 bgp neighbors are 'Established' 
+      assert: { that: "bgp_neighbors[item].state == 'Established'" }
+      with_items: "{{ bgp_neighbor_list }}"
+  rescue:
+    - name: Note reason for failure
+      debug:
+        msg: "The state of all the ipv4 bgp neighbors is not 'Established'.  Fix that before running this test"
+    - name: Force the command to fail after outputing failure message
+      assert:
+        that: False
 
 - name: call subtask to test each ipv4 neighbor
   include: roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml neighbor={{ item }}
@@ -34,9 +42,14 @@
   set_fact:
     bgp_neighbor_list: "{{ bgp_neighbors.keys() | list }}"
 
-- name: verify bgp ipv6 neighbors are 'Established' or 'Active'
-  assert: { that: "bgp_neighbors[item].state in ['Established', 'Active']" }
-  with_items: "{{ bgp_neighbor_list }}"
+- block:
+    - name: verify ipv4 bgp neighbors are 'Established' 
+      assert: { that: "bgp_neighbors[item].state == 'Established'" }
+      with_items: "{{ bgp_neighbor_list }}"
+  rescue:
+    - name: Note reason for failure
+      debug:
+        msg: "The state of all the ipv6 bgp neighbors is not 'Established'.  Fix that before running this test"
 
 - name: call subtask to test each ipv6 neighbor
   include: roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml neighbor={{ item }}

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv4_bounce_neighbor.yml
@@ -35,10 +35,10 @@
     set_fact:
       subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv4Unicast.peers }}"
 
-  - name: verify bgp neighbor is 'Established' or 'Active'
-    assert: { that: "subtask_bgp_neighbor[neighbor].state in ['Established', 'Active']" }
+  - name: verify bgp neighbor is 'Established' 
+    assert: { that: "subtask_bgp_neighbor[neighbor].state == 'Established'" }
 
-- rescue:
+  rescue:
   - name: start up neighbor links due to failed test
     shell: config bgp startup neighbor {{ neighbor }}
     become: yes

--- a/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
+++ b/ansible/roles/test/tasks/bgp_neighbor/bgp_neighbor_test_ipv6_bounce_neighbor.yml
@@ -36,9 +36,9 @@
       subtask_bgp_neighbor: "{{ (output.stdout|from_json).ipv6Unicast.peers }}"
 
   - name: verify bgp neighbor is 'Established'
-    assert: { that: "subtask_bgp_neighbor[neighbor].state in ['Established', 'Active']" }
+    assert: { that: "subtask_bgp_neighbor[neighbor].state == 'Established'" }
 
-- rescue:
+  rescue:
   - name: start up neighbor link due to failed test
     shell: config bgp startup neighbor {{ neighbor }}
     become: yes


### PR DESCRIPTION
Updates based on feedback from vasant
- Made the pass state only Established

Other changes
- Found that my rescue blocks weren't doing anything in the sub files, fixed that
- Forced test to stop if pre-conditions were not met
- improved debug messages
