### PR TITLE
Lafe 61 tab completion for clear and show commands

### DIFF
--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -1,0 +1,10 @@
+- name: test
+  debug: 
+    msg: this is a debug
+
+- name: import file
+  include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
+  with_items: 
+    - show
+    - show clock
+

--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -4,9 +4,8 @@
 # If the command will just display the current directory when tab completing, enter `False`
 - name: set commands to try and expected results
   set_fact:
-    sonic_commands:
+    sonic_show_commands:
       - show: True
-      - sonic-clear: True
       - show aaa: False
       - show acl: True
       - show arp: False
@@ -15,6 +14,7 @@
       - show ecn: False
       - show environment: False
       - show interfaces: True
+
       - show ip: True
       - show ipv6: True
       - show line: False
@@ -25,6 +25,7 @@
       - show mmu: False 
       - show ndp: False
       - show ntp: False
+
       - show pfc: True
       - show platform: True
       - show priority-group: True
@@ -35,6 +36,7 @@
       - show runningconfiguration: True
       - show services: False
       - show startupconfiguration: True
+
       - show system-memory: False
       - show tacacs: False
       - show techsupport: False
@@ -45,6 +47,7 @@
       - show warm_restart: True
       - show watermark: True
       - show acl rule: False
+
       - show acl table: False
       - show bgp attribute-info: False
       - show bgp cidr-only: False
@@ -55,6 +58,7 @@
       - show bgp detail: False
       - show bgp filter-list: False
       - show bgp ipv4: False
+
       - show bgp ipv6: False
       - show bgp json: False
       - show bgp large-community: False
@@ -65,6 +69,7 @@
       - show bgp paths: False
       - show bgp peer-group: False
       - show bgp prefix-list: False
+
       - show bgp regexp: False
       - show bgp route-leak: False
       - show bgp route-map: False
@@ -75,6 +80,7 @@
       - show bgp views: False
       - show bgp vrf: False
       - show bgp vrfs: False
+
       - show bgp cidr-only json: False
       - show bgp community accept-own: False
       - show bgp community accept-own-nexthop: False
@@ -85,6 +91,7 @@
       - show bgp community llgr-stale: False
       - show bgp community local-AS: False
       - show bgp community no-advertise: False
+
       - show bgp community no-export: False
       - show bgp community route-filter-translated-v4: False
       - show bgp community route-filter-translated-v6: False
@@ -95,6 +102,7 @@
       - show bgp community accept-own-nexthop json: False
       - show bgp community accept-own-nexthop : False
       - show bgp community blackhole exact-match: False
+
       - show bgp community blackhole json: False
       - show bgp community exact-match json: False
       - show bgp community graceful-shutdown exact-match: False
@@ -106,6 +114,7 @@
       - show bgp community llgr-stale json: False
       - show bgp community local-AS exact-match: False
       - show bgp community local-AS json: False
+
       - show bgp community no-advertise exact-match: False
       - show bgp community no-advertise json: False
       - show bgp community no-export exact-match: False
@@ -116,6 +125,7 @@
       - show bgp community route-filter-translated-v4 json: False
       - show bgp community route-filter-translated-v6 exact-match: False
       - show bgp community route-filter-translated-v6 json: False
+
       - show bgp community route-filter-v4 exact-match: False
       - show bgp community route-filter-v4 json: False
       - show bgp dampening dampened-paths: False
@@ -126,6 +136,7 @@
       - show bgp ipv4 community: False
       - show bgp ipv4 community-list: False
       - show bgp ipv4 dampening: False
+
       - show bgp ipv4 filter-list: False
       - show bgp ipv4 flowspec: False
       - show bgp ipv4 json: False
@@ -136,6 +147,7 @@
       - show bgp ipv4 neighbors: False
       - show bgp ipv4 prefix-list: False
       - show bgp ipv4 regexp: False
+
       - show bgp ipv4 route-leak: False
       - show bgp ipv4 route-map: False
       - show bgp ipv4 statistics: False
@@ -146,6 +158,7 @@
       - show bgp ipv6 cidr-only: False
       - show bgp ipv6 community: False
       - show bgp ipv6 community-list: False
+
       - show bgp ipv6 dampening: False
       - show bgp ipv6 filter-list: False
       - show bgp ipv6 flowspec: False
@@ -156,6 +169,7 @@
       - show bgp ipv6 multicast: False
       - show bgp ipv6 neighbors: False
       - show bgp ipv6 prefix-list: False
+
       - show bgp ipv6 regexp: False
       - show bgp ipv6 route-leak: False
       - show bgp ipv6 route-map: False
@@ -166,6 +180,7 @@
       - show bgp ipv6 vpn: False
       - show bgp l2vpn evpn: False
       - show bgp large-community json: False
+
       - show bgp martian next-hop: False
       - show bgp multicast paths: False
       - show bgp neighbors json: False
@@ -176,6 +191,7 @@
       - show bgp update-groups advertise-queue: False
       - show bgp update-groups advertised-routes: False
       - show bgp update-groups packet-queue: False
+
       - show bgp update-groups statistics: False
       - show bgp update-groups advertise-queue advertise-queue: False
       - show bgp update-groups advertise-queue advertised-routes: False
@@ -186,6 +202,7 @@
       - show bgp update-groups packet-queue advertise-queue: False
       - show bgp update-groups packet-queue advertised-routes: False
       - show bgp update-groups packet-queue packet-queue: False
+
       - show bgp update-groups statistics advertise-queue: False
       - show bgp update-groups statistics advertised-routes: False
       - show bgp update-groups statistics packet-queue: False
@@ -196,6 +213,7 @@
       - show interfaces counters: True
       - show interfaces description: False
       - show interfaces naming_mode: False
+
       - show interfaces neighbor: True
       - show interfaces portchannel: False
       - show interfaces status: False
@@ -206,6 +224,7 @@
       - show interfaces transceiver presence: False
       - show ip interfaces: False
       - show ip prefix-list: False
+
       - show ip protocol: False
       - show ip route: False
       - show ip prefix-list detail: False
@@ -216,6 +235,7 @@
       - show ip route eigrp: False
       - show ip route isis: False
       - show ip route json: False
+
       - show ip route kernel: False
       - show ip route nhrp: False
       - show ip route ospf: False
@@ -226,6 +246,7 @@
       - show ip route supernets-only: False
       - show ip route table: False
       - show ip route tag: False
+
       - show ip route vnc: False
       - show ip route vrf: False
       - show ipv6 interfaces: False
@@ -236,6 +257,7 @@
       - show ipv6 route connected: False
       - show ipv6 route isis: False
       - show ipv6 route json: False
+
       - show ipv6 route kernel: False
       - show ipv6 route nhrp: False
       - show ipv6 route ospf6: False
@@ -246,6 +268,7 @@
       - show ipv6 route summary: False
       - show ipv6 route table: False
       - show ipv6 route tag: False
+
       - show ipv6 route vnc: False
       - show ipv6 route vrf: False
       - show lldp neighbors: False
@@ -256,6 +279,7 @@
       - show platform syseeprom: False
       - show priority-group persistent-watermark: True
       - show priority-group watermark: True
+
       - show priority-group persistent-watermark headroom: False
       - show priority-group persistent-watermark shared: False
       - show priority-group watermark headroom: False
@@ -266,6 +290,7 @@
       - show queue counters: False
       - show queue persistent-watermark: True
       - show queue watermark: True
+
       - show queue persistent-watermark multicast: False
       - show queue persistent-watermark unicast: False
       - show queue watermark multicast: False
@@ -276,12 +301,40 @@
       - show runningconfiguration ntp: False
       - show runningconfiguration snmp: False
       - show startupconfiguration bgp: False
+
       - show vlan brief: False
       - show vlan config: False
       - show warm_restart config: False
       - show warm_restart state: False
       - show watermark telemetry: True
       - show watermark telemetry interval: False
+
+    sonic_clear_commands:
+      - sonic-clear: True
+      - sonic-clear arp: False
+      - sonic-clear counters: False
+      - sonic-clear line: False
+      - sonic-clear pfccounters: False
+      - sonic-clear rifcounters: False
+      - sonic-clear bgp: False
+      - sonic-clear fdb: True
+      - sonic-clear fdb all: False
+      - sonic-clear ipv6: False
+
+      - sonic-clear ndp: False
+      - sonic-clear priority-group: True
+      - sonic-clear queuecounters: False
+      - sonic-clear ip: True
+      - sonic-clear ip arp: False
+      - sonic-clear ip ndp: False
+      - sonic-clear queue: True
+      - sonic-clear queue persistent-watermark: True
+      - sonic-clear queue watermark: True
+      - sonic-clear queue persistent-watermark multicast: False
+
+      - sonic-clear queue persistent-watermark unicast : False
+      - sonic-clear queue watermark multicast: False
+      - sonic-clear queue watermark unicast: False
 
 - block:
   - name: create a file to use in verification of the commands
@@ -290,9 +343,13 @@
       dest: ~/testfile.deleteme
       force: no
 
-  - name: test the commands
+  - name: test the show commands
     include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml data={{ item }}
-    with_items: sonic_commands
+    with_items: sonic_show_commands
+
+  - name: test the clear commands
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml data={{ item }}
+    with_items: sonic_clear_commands
 
   always:
   - name: delete the verification file 

--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -1,340 +1,44 @@
 # Enter all commands to be tab completed in the dictionary in this step.
 #
-# If the command should provide output on tab completion, set the value to `True`
-# If the command will just display the current directory when tab completing, enter `False`
+# Commands in this list have been found to have tab completions.  
+
 - name: set commands to try and expected results
   set_fact:
     sonic_show_commands:
-      - show: True
-      - show aaa: False
-      - show acl: True
-      - show arp: False
-      - show bgp: False
-      - show clock: False
-      - show ecn: False
-      - show environment: False
-      - show interfaces: True
-
-      - show ip: True
-      - show ipv6: True
-      - show line: False
-      - show lldp: True
-      - show logging: False
-      - show mac: False
-      - show mirror_session: False
-      - show mmu: False 
-      - show ndp: False
-      - show ntp: False
-
-      - show pfc: True
-      - show platform: True
-      - show priority-group: True
-      - show processes: True
-      - show queue: True
-      - show reboot-cause: False
-      - show route-map: False
-      - show runningconfiguration: True
-      - show services: False
-      - show startupconfiguration: True
-
-      - show system-memory: False
-      - show tacacs: False
-      - show techsupport: False
-      - show uptime: False
-      - show users: False
-      - show version: False
-      - show vlan: True
-      - show warm_restart: True
-      - show watermark: True
-      - show acl rule: False
-
-      - show acl table: False
-      - show bgp attribute-info: False
-      - show bgp cidr-only: False
-      - show bgp community: False
-      - show bgp community-info: False
-      - show bgp community-list: False
-      - show bgp dampening: False
-      - show bgp detail: False
-      - show bgp filter-list: False
-      - show bgp ipv4: False
-
-      - show bgp ipv6: False
-      - show bgp json: False
-      - show bgp large-community: False
-      - show bgp large-community-list: False
-      - show bgp memory: False
-      - show bgp neighbors: False
-      - show bgp nexthop: False
-      - show bgp paths: False
-      - show bgp peer-group: False
-      - show bgp prefix-list: False
-
-      - show bgp regexp: False
-      - show bgp route-leak: False
-      - show bgp route-map: False
-      - show bgp statistics: False
-      - show bgp summary: False
-      - show bgp update-groups: False
-      - show bgp view: False
-      - show bgp views: False
-      - show bgp vrf: False
-      - show bgp vrfs: False
-
-      - show bgp cidr-only json: False
-      - show bgp community accept-own: False
-      - show bgp community accept-own-nexthop: False
-      - show bgp community blackhole: False
-      - show bgp community exact-match: False
-      - show bgp community graceful-shutdown: False
-      - show bgp community json: False
-      - show bgp community llgr-stale: False
-      - show bgp community local-AS: False
-      - show bgp community no-advertise: False
-
-      - show bgp community no-export: False
-      - show bgp community route-filter-translated-v4: False
-      - show bgp community route-filter-translated-v6: False
-      - show bgp community iroute-filter-v4: False
-      - show bgp community accept-own exact-match: False
-      - show bgp community accept-own json: False
-      - show bgp community accept-own-nexthop exact-match: False
-      - show bgp community accept-own-nexthop json: False
-      - show bgp community accept-own-nexthop : False
-      - show bgp community blackhole exact-match: False
-
-      - show bgp community blackhole json: False
-      - show bgp community exact-match json: False
-      - show bgp community graceful-shutdown exact-match: False
-      - show bgp community graceful-shutdown json: False
-      - show bgp community graceful-shutdown no-peer: False
-      - show bgp community graceful-shutdown exact-match json: False
-      - show bgp community graceful-shutdown no-peer exact-match: False
-      - show bgp community llgr-stale exact-match: False
-      - show bgp community llgr-stale json: False
-      - show bgp community local-AS exact-match: False
-      - show bgp community local-AS json: False
-
-      - show bgp community no-advertise exact-match: False
-      - show bgp community no-advertise json: False
-      - show bgp community no-export exact-match: False
-      - show bgp community no-export json: False
-      - show bgp community no-llgr exact-match: False
-      - show bgp community no-llgr json: False
-      - show bgp community route-filter-translated-v4 exact-match: False
-      - show bgp community route-filter-translated-v4 json: False
-      - show bgp community route-filter-translated-v6 exact-match: False
-      - show bgp community route-filter-translated-v6 json: False
-
-      - show bgp community route-filter-v4 exact-match: False
-      - show bgp community route-filter-v4 json: False
-      - show bgp dampening dampened-paths: False
-      - show bgp dampening flap-statistics: False
-      - show bgp dampening parameters: False
-      - show bgp detail json: False
-      - show bgp ipv4 cidr-only: False
-      - show bgp ipv4 community: False
-      - show bgp ipv4 community-list: False
-      - show bgp ipv4 dampening: False
-
-      - show bgp ipv4 filter-list: False
-      - show bgp ipv4 flowspec: False
-      - show bgp ipv4 json: False
-      - show bgp ipv4 labeled-unicast: False
-      - show bgp ipv4 large-community: False
-      - show bgp ipv4 large-community-list: False
-      - show bgp ipv4 multicast: False
-      - show bgp ipv4 neighbors: False
-      - show bgp ipv4 prefix-list: False
-      - show bgp ipv4 regexp: False
-
-      - show bgp ipv4 route-leak: False
-      - show bgp ipv4 route-map: False
-      - show bgp ipv4 statistics: False
-      - show bgp ipv4 summary: False
-      - show bgp ipv4 unicast: False
-      - show bgp ipv4 update-groups: False
-      - show bgp ipv4 vpn: False
-      - show bgp ipv6 cidr-only: False
-      - show bgp ipv6 community: False
-      - show bgp ipv6 community-list: False
-
-      - show bgp ipv6 dampening: False
-      - show bgp ipv6 filter-list: False
-      - show bgp ipv6 flowspec: False
-      - show bgp ipv6 json: False
-      - show bgp ipv6 labeled-unicast: False
-      - show bgp ipv6 large-community: False
-      - show bgp ipv6 large-community-list: False
-      - show bgp ipv6 multicast: False
-      - show bgp ipv6 neighbors: False
-      - show bgp ipv6 prefix-list: False
-
-      - show bgp ipv6 regexp: False
-      - show bgp ipv6 route-leak: False
-      - show bgp ipv6 route-map: False
-      - show bgp ipv6 statistics: False
-      - show bgp ipv6 summary: False
-      - show bgp ipv6 unicast: False
-      - show bgp ipv6 update-groups: False
-      - show bgp ipv6 vpn: False
-      - show bgp l2vpn evpn: False
-      - show bgp large-community json: False
-
-      - show bgp martian next-hop: False
-      - show bgp multicast paths: False
-      - show bgp neighbors json: False
-      - show bgp nexthop detail: False
-      - show bgp route-leak json: False
-      - show bgp summary json: False
-      - show bgp unicast paths: False
-      - show bgp update-groups advertise-queue: False
-      - show bgp update-groups advertised-routes: False
-      - show bgp update-groups packet-queue: False
-
-      - show bgp update-groups statistics: False
-      - show bgp update-groups advertise-queue advertise-queue: False
-      - show bgp update-groups advertise-queue advertised-routes: False
-      - show bgp update-groups advertise-queue packet-queue: False
-      - show bgp update-groups advertised-routes advertise-queue: False
-      - show bgp update-groups advertised-routes advertised-routes: False
-      - show bgp update-groups advertised-routes packet-queue: False
-      - show bgp update-groups packet-queue advertise-queue: False
-      - show bgp update-groups packet-queue advertised-routes: False
-      - show bgp update-groups packet-queue packet-queue: False
-
-      - show bgp update-groups statistics advertise-queue: False
-      - show bgp update-groups statistics advertised-routes: False
-      - show bgp update-groups statistics packet-queue: False
-      - show bgp view all: False
-      - show bgp vpn paths: False
-      - show bgp vrf all: False
-      - show bgp vrfs json: False
-      - show interfaces counters: True
-      - show interfaces description: False
-      - show interfaces naming_mode: False
-
-      - show interfaces neighbor: True
-      - show interfaces portchannel: False
-      - show interfaces status: False
-      - show interfaces transceiver: True
-      - show interfaces neighbor expected: False
-      - show interfaces transceiver eeprom: False
-      - show interfaces transceiver lpmode: False
-      - show interfaces transceiver presence: False
-      - show ip interfaces: False
-      - show ip prefix-list: False
-
-      - show ip protocol: False
-      - show ip route: False
-      - show ip prefix-list detail: False
-      - show ip prefix-list summary: False
-      - show ip route babel: False
-      - show ip route bgp: False
-      - show ip route connected: False
-      - show ip route eigrp: False
-      - show ip route isis: False
-      - show ip route json: False
-
-      - show ip route kernel: False
-      - show ip route nhrp: False
-      - show ip route ospf: False
-      - show ip route rip: False
-      - show ip route sharp: False
-      - show ip route static: False
-      - show ip route summary: False
-      - show ip route supernets-only: False
-      - show ip route table: False
-      - show ip route tag: False
-
-      - show ip route vnc: False
-      - show ip route vrf: False
-      - show ipv6 interfaces: False
-      - show ipv6 protocol: False
-      - show ipv6 route: False
-      - show ipv6 route babel: False
-      - show ipv6 route bgp: False
-      - show ipv6 route connected: False
-      - show ipv6 route isis: False
-      - show ipv6 route json: False
-
-      - show ipv6 route kernel: False
-      - show ipv6 route nhrp: False
-      - show ipv6 route ospf6: False
-      - show ipv6 route ripng: False
-      - show ipv6 route sharp: False
-      - show ipv6 route : False
-      - show ipv6 route static: False
-      - show ipv6 route summary: False
-      - show ipv6 route table: False
-      - show ipv6 route tag: False
-
-      - show ipv6 route vnc: False
-      - show ipv6 route vrf: False
-      - show lldp neighbors: False
-      - show lldp table: False
-      - show pfc counters: False
-      - show platform psustatus: False
-      - show platform summary: False
-      - show platform syseeprom: False
-      - show priority-group persistent-watermark: True
-      - show priority-group watermark: True
-
-      - show priority-group persistent-watermark headroom: False
-      - show priority-group persistent-watermark shared: False
-      - show priority-group watermark headroom: False
-      - show priority-group watermark shared: False
-      - show processes cpu: False
-      - show processes memory: False
-      - show processes summary: False
-      - show queue counters: False
-      - show queue persistent-watermark: True
-      - show queue watermark: True
-
-      - show queue persistent-watermark multicast: False
-      - show queue persistent-watermark unicast: False
-      - show queue watermark multicast: False
-      - show queue watermark unicast: False
-      - show runningconfiguration all: False
-      - show runningconfiguration bgp: False
-      - show runningconfiguration interfaces: False
-      - show runningconfiguration ntp: False
-      - show runningconfiguration snmp: False
-      - show startupconfiguration bgp: False
-
-      - show vlan brief: False
-      - show vlan config: False
-      - show warm_restart config: False
-      - show warm_restart state: False
-      - show watermark telemetry: True
-      - show watermark telemetry interval: False
+      - show
+      - show acl
+      - show bgp  # This test fails as of the writing of this test
+      - show interfaces
+      - show ip
+      - show ipv6
+      - show lldp
+      - show pfc
+      - show platform
+      - show priority-group
+      - show processes
+      - show queue
+      - show runningconfiguration
+      - show startupconfiguration
+      - show vlan
+      - show warm_restart
+      - show watermark
+      - show interfaces counters
+      - show interfaces neighbor
+      - show interfaces transceiver
+      - show priority-group watermark
+      - show queue persistent-watermark
+      - show queue watermark
+      - show watermark telemetry
 
     sonic_clear_commands:
-      - sonic-clear: True
-      - sonic-clear arp: False
-      - sonic-clear counters: False
-      - sonic-clear line: False
-      - sonic-clear pfccounters: False
-      - sonic-clear rifcounters: False
-      - sonic-clear bgp: False
-      - sonic-clear fdb: True
-      - sonic-clear fdb all: False
-      - sonic-clear ipv6: False
-
-      - sonic-clear ndp: False
-      - sonic-clear priority-group: True
-      - sonic-clear queuecounters: False
-      - sonic-clear ip: True
-      - sonic-clear ip arp: False
-      - sonic-clear ip ndp: False
-      - sonic-clear queue: True
-      - sonic-clear queue persistent-watermark: True
-      - sonic-clear queue watermark: True
-      - sonic-clear queue persistent-watermark multicast: False
-
-      - sonic-clear queue persistent-watermark unicast : False
-      - sonic-clear queue watermark multicast: False
-      - sonic-clear queue watermark unicast: False
+      - sonic-clear
+      - sonic-clear bgp   # This test fails as of the writing of this test
+      - sonic-clear fdb
+      - sonic-clear priority-group
+      - sonic-clear ip
+      - sonic-clear queue
+      - sonic-clear queue persistent-watermark
+      - sonic-clear queue watermark
 
 - block:
   - name: create a file to use in verification of the commands
@@ -344,11 +48,11 @@
       force: no
 
   - name: test the show commands
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml data={{ item }}
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
     with_items: sonic_show_commands
 
   - name: test the clear commands
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml data={{ item }}
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
     with_items: sonic_clear_commands
 
   always:

--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -5,103 +5,283 @@
 - name: set commands to try and expected results
   set_fact:
     sonic_commands:
-      top_level:
-        show: True
-        sonic-clear: True
-      show: 
-        show aaa: False
-        show acl: True
-        show arp: False
-        show bgp: False
-        show clock: False
-        show ecn: False
-        show environment: False
-        show interfaces: True
-        show ip: True
-        show ipv6: True
-        show line: False
-        show lldp: True
-        show logging: False
-        show mac: False
-        show mirror_session: False
-        show mmu: False 
-        show ndp: False
-        show ntp: False
-        show pfc: True
-        show platform: True
-        show priority-group: True
-        show processes: True
-        show queue: True
-        show reboot-cause: False
-        show route-map: False
-        show runningconfiguration: True
-        show services: False
-        show startupconfiguration: True
-        show system-memory: False
-        show tacacs: False
-        show techsupport: False
-        show uptime: False
-        show users: False
-        show version: False
-        show vlan: True
-        show warm_restart: True
-        show watermark: True
-      show_acl:
-        show acl rule: False
-        show acl table: False
-      show_bgp:
-        show bgp attribute-info: False
-        show bgp cidr-only: False
-        show bgp community: False
-        show bgp community-info: False
-        show bgp community-list: False
-        show bgp dampening: False
-        show bgp detail: False
-        show bgp filter-list: False
-        show bgp ipv4: False
-        show bgp ipv6: False
-        show bgp json: False
-        show bgp large-community: False
-        show bgp large-community-list: False
-        show bgp memory: False
-        show bgp neighbors: False
-        show bgp nexthop: False
-        show bgp paths: False
-        show bgp peer-group: False
-        show bgp prefix-list: False
-        show bgp regexp: False
-        show bgp route-leak: False
-        show bgp route-map: False
-        show bgp statistics: False
-        show bgp summary: False
-        show bgp update-groups: False
-        show bgp view: False
-        show bgp views: False
-        show bgp vrf: False
-        show bgp vrfs: False
-      show_bgp_cidr_only:
-        show bgp cidr-only json: False
-      show_bgp_community:
-        show bgp community accept-own: False
-        show bgp community accept-own-nexthop: False
-        show bgp community blackhole: False
-        show bgp community exact-match: False
-        show bgp community graceful-shutdown: False
-        show bgp community json: False
-        show bgp community llgr-stale: False
-        show bgp community local-AS: False
-        show bgp community no-advertise: False
-        show bgp community no-export: False
-        show bgp community route-filter-translated-v4: False
-        show bgp community route-filter-translated-v6: False
-        show bgp community iroute-filter-v4: False
-      show_bgp_community_accept_own:
-        show bgp community accept-own exact-match: False
-        show bgp community accept-own json: False
-      show_bgp_community_accept_own_nexthop:
-        show bgp community accept-own-nexthop exact-match: False
-        show bgp community accept-own-nexthop json: False
-        show bgp community accept-own-nexthop : False
+      - show: True
+      - sonic-clear: True
+      - show aaa: False
+      - show acl: True
+      - show arp: False
+      - show bgp: False
+      - show clock: False
+      - show ecn: False
+      - show environment: False
+      - show interfaces: True
+      - show ip: True
+      - show ipv6: True
+      - show line: False
+      - show lldp: True
+      - show logging: False
+      - show mac: False
+      - show mirror_session: False
+      - show mmu: False 
+      - show ndp: False
+      - show ntp: False
+      - show pfc: True
+      - show platform: True
+      - show priority-group: True
+      - show processes: True
+      - show queue: True
+      - show reboot-cause: False
+      - show route-map: False
+      - show runningconfiguration: True
+      - show services: False
+      - show startupconfiguration: True
+      - show system-memory: False
+      - show tacacs: False
+      - show techsupport: False
+      - show uptime: False
+      - show users: False
+      - show version: False
+      - show vlan: True
+      - show warm_restart: True
+      - show watermark: True
+      - show acl rule: False
+      - show acl table: False
+      - show bgp attribute-info: False
+      - show bgp cidr-only: False
+      - show bgp community: False
+      - show bgp community-info: False
+      - show bgp community-list: False
+      - show bgp dampening: False
+      - show bgp detail: False
+      - show bgp filter-list: False
+      - show bgp ipv4: False
+      - show bgp ipv6: False
+      - show bgp json: False
+      - show bgp large-community: False
+      - show bgp large-community-list: False
+      - show bgp memory: False
+      - show bgp neighbors: False
+      - show bgp nexthop: False
+      - show bgp paths: False
+      - show bgp peer-group: False
+      - show bgp prefix-list: False
+      - show bgp regexp: False
+      - show bgp route-leak: False
+      - show bgp route-map: False
+      - show bgp statistics: False
+      - show bgp summary: False
+      - show bgp update-groups: False
+      - show bgp view: False
+      - show bgp views: False
+      - show bgp vrf: False
+      - show bgp vrfs: False
+      - show bgp cidr-only json: False
+      - show bgp community accept-own: False
+      - show bgp community accept-own-nexthop: False
+      - show bgp community blackhole: False
+      - show bgp community exact-match: False
+      - show bgp community graceful-shutdown: False
+      - show bgp community json: False
+      - show bgp community llgr-stale: False
+      - show bgp community local-AS: False
+      - show bgp community no-advertise: False
+      - show bgp community no-export: False
+      - show bgp community route-filter-translated-v4: False
+      - show bgp community route-filter-translated-v6: False
+      - show bgp community iroute-filter-v4: False
+      - show bgp community accept-own exact-match: False
+      - show bgp community accept-own json: False
+      - show bgp community accept-own-nexthop exact-match: False
+      - show bgp community accept-own-nexthop json: False
+      - show bgp community accept-own-nexthop : False
+      - show bgp community blackhole exact-match: False
+      - show bgp community blackhole json: False
+      - show bgp community exact-match json: False
+      - show bgp community graceful-shutdown exact-match: False
+      - show bgp community graceful-shutdown json: False
+      - show bgp community graceful-shutdown no-peer: False
+      - show bgp community graceful-shutdown exact-match json: False
+      - show bgp community graceful-shutdown no-peer exact-match: False
+      - show bgp community llgr-stale exact-match: False
+      - show bgp community llgr-stale json: False
+      - show bgp community local-AS exact-match: False
+      - show bgp community local-AS json: False
+      - show bgp community no-advertise exact-match: False
+      - show bgp community no-advertise json: False
+      - show bgp community no-export exact-match: False
+      - show bgp community no-export json: False
+      - show bgp community no-llgr exact-match: False
+      - show bgp community no-llgr json: False
+      - show bgp community route-filter-translated-v4 exact-match: False
+      - show bgp community route-filter-translated-v4 json: False
+      - show bgp community route-filter-translated-v6 exact-match: False
+      - show bgp community route-filter-translated-v6 json: False
+      - show bgp community route-filter-v4 exact-match: False
+      - show bgp community route-filter-v4 json: False
+      - show bgp dampening dampened-paths: False
+      - show bgp dampening flap-statistics: False
+      - show bgp dampening parameters: False
+      - show bgp detail json: False
+      - show bgp ipv4 cidr-only: False
+      - show bgp ipv4 community: False
+      - show bgp ipv4 community-list: False
+      - show bgp ipv4 dampening: False
+      - show bgp ipv4 filter-list: False
+      - show bgp ipv4 flowspec: False
+      - show bgp ipv4 json: False
+      - show bgp ipv4 labeled-unicast: False
+      - show bgp ipv4 large-community: False
+      - show bgp ipv4 large-community-list: False
+      - show bgp ipv4 multicast: False
+      - show bgp ipv4 neighbors: False
+      - show bgp ipv4 prefix-list: False
+      - show bgp ipv4 regexp: False
+      - show bgp ipv4 route-leak: False
+      - show bgp ipv4 route-map: False
+      - show bgp ipv4 statistics: False
+      - show bgp ipv4 summary: False
+      - show bgp ipv4 unicast: False
+      - show bgp ipv4 update-groups: False
+      - show bgp ipv4 vpn: False
+      - show bgp ipv6 cidr-only: False
+      - show bgp ipv6 community: False
+      - show bgp ipv6 community-list: False
+      - show bgp ipv6 dampening: False
+      - show bgp ipv6 filter-list: False
+      - show bgp ipv6 flowspec: False
+      - show bgp ipv6 json: False
+      - show bgp ipv6 labeled-unicast: False
+      - show bgp ipv6 large-community: False
+      - show bgp ipv6 large-community-list: False
+      - show bgp ipv6 multicast: False
+      - show bgp ipv6 neighbors: False
+      - show bgp ipv6 prefix-list: False
+      - show bgp ipv6 regexp: False
+      - show bgp ipv6 route-leak: False
+      - show bgp ipv6 route-map: False
+      - show bgp ipv6 statistics: False
+      - show bgp ipv6 summary: False
+      - show bgp ipv6 unicast: False
+      - show bgp ipv6 update-groups: False
+      - show bgp ipv6 vpn: False
+      - show bgp l2vpn evpn: False
+      - show bgp large-community json: False
+      - show bgp martian next-hop: False
+      - show bgp multicast paths: False
+      - show bgp neighbors json: False
+      - show bgp nexthop detail: False
+      - show bgp route-leak json: False
+      - show bgp summary json: False
+      - show bgp unicast paths: False
+      - show bgp update-groups advertise-queue: False
+      - show bgp update-groups advertised-routes: False
+      - show bgp update-groups packet-queue: False
+      - show bgp update-groups statistics: False
+      - show bgp update-groups advertise-queue advertise-queue: False
+      - show bgp update-groups advertise-queue advertised-routes: False
+      - show bgp update-groups advertise-queue packet-queue: False
+      - show bgp update-groups advertised-routes advertise-queue: False
+      - show bgp update-groups advertised-routes advertised-routes: False
+      - show bgp update-groups advertised-routes packet-queue: False
+      - show bgp update-groups packet-queue advertise-queue: False
+      - show bgp update-groups packet-queue advertised-routes: False
+      - show bgp update-groups packet-queue packet-queue: False
+      - show bgp update-groups statistics advertise-queue: False
+      - show bgp update-groups statistics advertised-routes: False
+      - show bgp update-groups statistics packet-queue: False
+      - show bgp view all: False
+      - show bgp vpn paths: False
+      - show bgp vrf all: False
+      - show bgp vrfs json: False
+      - show interfaces counters: True
+      - show interfaces description: False
+      - show interfaces naming_mode: False
+      - show interfaces neighbor: True
+      - show interfaces portchannel: False
+      - show interfaces status: False
+      - show interfaces transceiver: True
+      - show interfaces neighbor expected: False
+      - show interfaces transceiver eeprom: False
+      - show interfaces transceiver lpmode: False
+      - show interfaces transceiver presence: False
+      - show ip interfaces: False
+      - show ip prefix-list: False
+      - show ip protocol: False
+      - show ip route: False
+      - show ip prefix-list detail: False
+      - show ip prefix-list summary: False
+      - show ip route babel: False
+      - show ip route bgp: False
+      - show ip route connected: False
+      - show ip route eigrp: False
+      - show ip route isis: False
+      - show ip route json: False
+      - show ip route kernel: False
+      - show ip route nhrp: False
+      - show ip route ospf: False
+      - show ip route rip: False
+      - show ip route sharp: False
+      - show ip route static: False
+      - show ip route summary: False
+      - show ip route supernets-only: False
+      - show ip route table: False
+      - show ip route tag: False
+      - show ip route vnc: False
+      - show ip route vrf: False
+      - show ipv6 interfaces: False
+      - show ipv6 protocol: False
+      - show ipv6 route: False
+      - show ipv6 route babel: False
+      - show ipv6 route bgp: False
+      - show ipv6 route connected: False
+      - show ipv6 route isis: False
+      - show ipv6 route json: False
+      - show ipv6 route kernel: False
+      - show ipv6 route nhrp: False
+      - show ipv6 route ospf6: False
+      - show ipv6 route ripng: False
+      - show ipv6 route sharp: False
+      - show ipv6 route : False
+      - show ipv6 route static: False
+      - show ipv6 route summary: False
+      - show ipv6 route table: False
+      - show ipv6 route tag: False
+      - show ipv6 route vnc: False
+      - show ipv6 route vrf: False
+      - show lldp neighbors: False
+      - show lldp table: False
+      - show pfc counters: False
+      - show platform psustatus: False
+      - show platform summary: False
+      - show platform syseeprom: False
+      - show priority-group persistent-watermark: True
+      - show priority-group watermark: True
+      - show priority-group persistent-watermark headroom: False
+      - show priority-group persistent-watermark shared: False
+      - show priority-group watermark headroom: False
+      - show priority-group watermark shared: False
+      - show processes cpu: False
+      - show processes memory: False
+      - show processes summary: False
+      - show queue counters: False
+      - show queue persistent-watermark: True
+      - show queue watermark: True
+      - show queue persistent-watermark multicast: False
+      - show queue persistent-watermark unicast: False
+      - show queue watermark multicast: False
+      - show queue watermark unicast: False
+      - show runningconfiguration all: False
+      - show runningconfiguration bgp: False
+      - show runningconfiguration interfaces: False
+      - show runningconfiguration ntp: False
+      - show runningconfiguration snmp: False
+      - show startupconfiguration bgp: False
+      - show vlan brief: False
+      - show vlan config: False
+      - show warm_restart config: False
+      - show warm_restart state: False
+      - show watermark telemetry: True
+      - show watermark telemetry interval: False
 
 - block:
   - name: create a file to use in verification of the commands
@@ -110,29 +290,9 @@
       dest: ~/testfile.deleteme
       force: no
 
-  - name: test top level commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.top_level
-  
-  - name: test show commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.show
-  
-  - name: test show_acl commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.show_acl
-  
-  - name: test show_bgp commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.show_bgp
-  
-  - name: test show_bgp_cidr_only commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.show_bgp_cidr_only
-  
-  - name: test show_bgp commands 
-    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
-    with_dict: sonic_commands.show_bgp_community
+  - name: test the commands
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml data={{ item }}
+    with_items: sonic_commands
 
   always:
   - name: delete the verification file 

--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -1,10 +1,142 @@
-- name: test
-  debug: 
-    msg: this is a debug
+# Enter all commands to be tab completed in the dictionary in this step.
+#
+# If the command should provide output on tab completion, set the value to `True`
+# If the command will just display the current directory when tab completing, enter `False`
+- name: set commands to try and expected results
+  set_fact:
+    sonic_commands:
+      top_level:
+        show: True
+        sonic-clear: True
+      show: 
+        show aaa: False
+        show acl: True
+        show arp: False
+        show bgp: False
+        show clock: False
+        show ecn: False
+        show environment: False
+        show interfaces: True
+        show ip: True
+        show ipv6: True
+        show line: False
+        show lldp: True
+        show logging: False
+        show mac: False
+        show mirror_session: False
+        show mmu: False 
+        show ndp: False
+        show ntp: False
+        show pfc: True
+        show platform: True
+        show priority-group: True
+        show processes: True
+        show queue: True
+        show reboot-cause: False
+        show route-map: False
+        show runningconfiguration: True
+        show services: False
+        show startupconfiguration: True
+        show system-memory: False
+        show tacacs: False
+        show techsupport: False
+        show uptime: False
+        show users: False
+        show version: False
+        show vlan: True
+        show warm_restart: True
+        show watermark: True
+      show_acl:
+        show acl rule: False
+        show acl table: False
+      show_bgp:
+        show bgp attribute-info: False
+        show bgp cidr-only: False
+        show bgp community: False
+        show bgp community-info: False
+        show bgp community-list: False
+        show bgp dampening: False
+        show bgp detail: False
+        show bgp filter-list: False
+        show bgp ipv4: False
+        show bgp ipv6: False
+        show bgp json: False
+        show bgp large-community: False
+        show bgp large-community-list: False
+        show bgp memory: False
+        show bgp neighbors: False
+        show bgp nexthop: False
+        show bgp paths: False
+        show bgp peer-group: False
+        show bgp prefix-list: False
+        show bgp regexp: False
+        show bgp route-leak: False
+        show bgp route-map: False
+        show bgp statistics: False
+        show bgp summary: False
+        show bgp update-groups: False
+        show bgp view: False
+        show bgp views: False
+        show bgp vrf: False
+        show bgp vrfs: False
+      show_bgp_cidr_only:
+        show bgp cidr-only json: False
+      show_bgp_community:
+        show bgp community accept-own: False
+        show bgp community accept-own-nexthop: False
+        show bgp community blackhole: False
+        show bgp community exact-match: False
+        show bgp community graceful-shutdown: False
+        show bgp community json: False
+        show bgp community llgr-stale: False
+        show bgp community local-AS: False
+        show bgp community no-advertise: False
+        show bgp community no-export: False
+        show bgp community route-filter-translated-v4: False
+        show bgp community route-filter-translated-v6: False
+        show bgp community iroute-filter-v4: False
+      show_bgp_community_accept_own:
+        show bgp community accept-own exact-match: False
+        show bgp community accept-own json: False
+      show_bgp_community_accept_own_nexthop:
+        show bgp community accept-own-nexthop exact-match: False
+        show bgp community accept-own-nexthop json: False
+        show bgp community accept-own-nexthop : False
 
-- name: import file
-  include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
-  with_items: 
-    - show
-    - show clock
+- block:
+  - name: create a file to use in verification of the commands
+    copy:
+      content: ""
+      dest: ~/testfile.deleteme
+      force: no
+
+  - name: test top level commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.top_level
+  
+  - name: test show commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.show
+  
+  - name: test show_acl commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.show_acl
+  
+  - name: test show_bgp commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.show_bgp
+  
+  - name: test show_bgp_cidr_only commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.show_bgp_cidr_only
+  
+  - name: test show_bgp commands 
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item.key }} expect_tab_fail={{ item.value }}
+    with_dict: sonic_commands.show_bgp_community
+
+  always:
+  - name: delete the verification file 
+    file:
+      state: absent
+      path: ~/testfile.deleteme
 

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -4,7 +4,7 @@
     set_fact:
       command: "{{ item.key }}"
       autocomplete: "{{ item.value }}"
-    with_dict: item
+    with_dict: data 
 
   # This command prints the command followed by 2 tabs and then ctrl+u to clear the input
   - name: Execute the command "{{ command }}" followed by [tab] [tab] 

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -1,26 +1,33 @@
+# This will exercize the tab autocomplete but should prevent execution of any commands
 - block:
-  # This will exercize the tab autocomplete but should prevent execution of any commands
-  # This also has the added benefit of making long running show commands not execute so the play is faster
-  - name: Execute the command '{{ command }}' followed by [tab] [tab] 
-    raw: "echo {{ command }} $'\t'$'\t' fake | bash -i 2>&1"
-    register: tab_command_output
-    failed_when: > 
-      ('testfile.deleteme' not in tab_command_output.stdout) and
-      ('Error: Got unexpected extra argument' not in tab_command_output.stdout) and
-      ('Error: No such command' not in tab_command_output.stdout)
+  - name: set values
+    set_fact:
+      command: "{{ item.key }}"
+      autocomplete: "{{ item.value }}"
+    with_dict: item
 
-  - name: verify 'testfile.deleteme' not in the output of {{ item.key }}
+  # This command prints the command followed by 2 tabs and then ctrl+u to clear the input
+  - name: Execute the command "{{ command }}" followed by [tab] [tab] 
+    raw: "printf '{{ command }} \x09\x09\x15' | bash -i 2>&1"
+    register: tab_command_output
+
+  # When the object is true, verify something other than the directory is in stdout
+  - name: verify 'testfile.deleteme' not in the output of {{ command }}
     assert:
       that: "'testfile.deleteme' not in tab_command_output.stdout"
-    when: "{{ item.value }} == True"
-    
-  - name: verify 'testfile.deleteme' in the output of {{ item.key }} 
+    when: "{{ autocomplete }} == True"
+
+  # When the object is false, verify the directory is in the output  
+  - name: verify 'testfile.deleteme' in the output of {{ command }} 
     assert:
       that: "'testfile.deleteme' in tab_command_output.stdout"
-    when: "{{ item.value }} == False"
+    when: "{{ autocomplete }} == False"
 
   rescue:
-  - name: output
+  - name: Error message
     debug:
-      msg: the command failed
+      msg: "the command '{{ command }}' failed"
 
+  - name: Variable Dump
+    debug:
+      var: tab_command_output

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -1,29 +1,26 @@
-- name: test
-  debug:
-    var: command
-
 - block:
-  - name: show question
-    shell: "{{ command }}"
-    register: question_command_output
-
-  - name: output results
-    debug:
-      var: question_command_output.stdout
-
-  - name: show command tab tab
-    raw: "echo {{ command }} $'\t'$'\t' | bash -i 2>&1"
+  # This will exercize the tab autocomplete but should prevent execution of any commands
+  # This also has the added benefit of making long running show commands not execute so the play is faster
+  - name: Execute the command '{{ command }}' followed by [tab] [tab] 
+    raw: "echo {{ command }} $'\t'$'\t' fake | bash -i 2>&1"
     register: tab_command_output
-    
-  - name: outpt tab results
-    debug: 
-      var: tab_command_output.stdout
+    failed_when: > 
+      ('testfile.deleteme' not in tab_command_output.stdout) and
+      ('Error: Got unexpected extra argument' not in tab_command_output.stdout) and
+      ('Error: No such command' not in tab_command_output.stdout)
 
-  - assert:
-      that: question_command_output.stdout == tab_command_output.stdout
-  
+  - name: verify 'testfile.deleteme' not in the output of {{ item.key }}
+    assert:
+      that: "'testfile.deleteme' not in tab_command_output.stdout"
+    when: "{{ item.value }} == True"
+    
+  - name: verify 'testfile.deleteme' in the output of {{ item.key }} 
+    assert:
+      that: "'testfile.deleteme' in tab_command_output.stdout"
+    when: "{{ item.value }} == False"
+
   rescue:
   - name: output
     debug:
-      msg: it failed
+      msg: the command failed
 

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -1,27 +1,15 @@
-# This will exercize the tab autocomplete but should prevent execution of any commands
+# This will exercise the tab autocomplete but should prevent execution of any commands
 - block:
-  - name: set values
-    set_fact:
-      command: "{{ item.key }}"
-      autocomplete: "{{ item.value }}"
-    with_dict: data 
 
   # This command prints the command followed by 2 tabs and then ctrl+u to clear the input
   - name: Execute the command "{{ command }}" followed by [tab] [tab] 
     raw: "printf '{{ command }} \x09\x09\x15' | bash -i 2>&1"
     register: tab_command_output
 
-  # When the object is true, verify something other than the directory is in stdout
+  # Verify something other than the directory is in stdout
   - name: verify 'testfile.deleteme' not in the output of {{ command }}
     assert:
       that: "'testfile.deleteme' not in tab_command_output.stdout"
-    when: "{{ autocomplete }} == True"
-
-  # When the object is false, verify the directory is in the output  
-  - name: verify 'testfile.deleteme' in the output of {{ command }} 
-    assert:
-      that: "'testfile.deleteme' in tab_command_output.stdout"
-    when: "{{ autocomplete }} == False"
 
   rescue:
   - name: Error message

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -1,0 +1,29 @@
+- name: test
+  debug:
+    var: command
+
+- block:
+  - name: show question
+    shell: "{{ command }}"
+    register: question_command_output
+
+  - name: output results
+    debug:
+      var: question_command_output.stdout
+
+  - name: show command tab tab
+    raw: "echo {{ command }} $'\t'$'\t' | bash -i 2>&1"
+    register: tab_command_output
+    
+  - name: outpt tab results
+    debug: 
+      var: tab_command_output.stdout
+
+  - assert:
+      that: question_command_output.stdout == tab_command_output.stdout
+  
+  rescue:
+  - name: output
+    debug:
+      msg: it failed
+

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -232,6 +232,10 @@ testcases:
     sonic_cli:
       filename: test_sonic_show_cli.yml
       topologies: [t0-8, t1-8]
+
+    sonic_cli_tab:
+      filename: sonic_cli_tab.yml
+      topologies: [t0-8, t1-8]
       
     vlan:
       filename: vlantb.yml


### PR DESCRIPTION
add tab completion and cli tests.

Need to ask customer if we want the test to pass/fail based on what the tab completion should do or does do currently.

Also, the sonic-clear commands are not all the possible commands.

the `sonic-clear bgp` sub-commands don't auto complete.  Didn't see any reason to add all of those when none of then have any autocompletion.

