### PR TITLE
adding finals in prep for final review

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -252,6 +252,11 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ```
 - Requires switch connected to a VM set or PTF testbed
 
+#### Sonic CLI Tab test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_cli_tab -e testbed_name={TESTBED_NAME}
+```
+
 ##### Syslog test
 ```
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=syslog -e testbed_name={TESTBED_NAME}

--- a/ansible/roles/test/tasks/sonic_cli_tab.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab.yml
@@ -1,0 +1,63 @@
+# Enter all commands to be tab completed in the dictionary in this step.
+#
+# Commands in this list have been found to have tab completions.  
+
+- name: set commands to try and expected results
+  set_fact:
+    sonic_show_commands:
+      - show
+      - show acl
+      - show bgp  # This test fails as of the writing of this test
+      - show interfaces
+      - show ip
+      - show ipv6
+      - show lldp
+      - show pfc
+      - show platform
+      - show priority-group
+      - show processes
+      - show queue
+      - show runningconfiguration
+      - show startupconfiguration
+      - show vlan
+      - show warm_restart
+      - show watermark
+      - show interfaces counters
+      - show interfaces neighbor
+      - show interfaces transceiver
+      - show priority-group watermark
+      - show queue persistent-watermark
+      - show queue watermark
+      - show watermark telemetry
+
+    sonic_clear_commands:
+      - sonic-clear
+      - sonic-clear bgp   # This test fails as of the writing of this test
+      - sonic-clear fdb
+      - sonic-clear priority-group
+      - sonic-clear ip
+      - sonic-clear queue
+      - sonic-clear queue persistent-watermark
+      - sonic-clear queue watermark
+
+- block:
+  - name: create a file to use in verification of the commands
+    copy:
+      content: ""
+      dest: ~/testfile.deleteme
+      force: no
+
+  - name: test the show commands
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
+    with_items: sonic_show_commands
+
+  - name: test the clear commands
+    include: roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml command={{ item }}
+    with_items: sonic_clear_commands
+
+  always:
+  - name: delete the verification file 
+    file:
+      state: absent
+      path: ~/testfile.deleteme
+

--- a/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
+++ b/ansible/roles/test/tasks/sonic_cli_tab/sonic_cli_tab_compare.yml
@@ -1,0 +1,21 @@
+# This will exercise the tab autocomplete but should prevent execution of any commands
+- block:
+
+  # This command prints the command followed by 2 tabs and then ctrl+u to clear the input
+  - name: Execute the command "{{ command }}" followed by [tab] [tab] 
+    raw: "printf '{{ command }} \x09\x09\x15' | bash -i 2>&1"
+    register: tab_command_output
+
+  # Verify something other than the directory is in stdout
+  - name: verify 'testfile.deleteme' not in the output of {{ command }}
+    assert:
+      that: "'testfile.deleteme' not in tab_command_output.stdout"
+
+  rescue:
+  - name: Error message
+    debug:
+      msg: "the command '{{ command }}' failed"
+
+  - name: Variable Dump
+    debug:
+      var: tab_command_output

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -221,6 +221,10 @@ testcases:
       filename: service_acl.yml
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    sonic_cli_tab:
+      filename: sonic_cli_tab.yml
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t1]
+
     snmp:
       filename: snmp.yml
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]


### PR DESCRIPTION
### Description of PR
Adds the **sonic_cli_tab** test to the repo for testing tab completion of the **show** and **sonic-clear** tab completion options

Summary:
Uses a list of commands that are known to have sub-commands and verifies that they work and don't cause the directory to be shown instead.

NOTE: The **show bgp** and the **sonic-clear bgp** tab completions currently fail.  Both of those commands do have sub-commands, but the options are not offered when doing tab completions with these 2 commands.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [X] Test case(new/improvement)

### Approach
Created a list of commands that currently provide options when doing tab completion and verify the directory is not output.

#### How did you do it?
Found a way to send tab completions, capture the output, then send ctrl-u to clear the input so as to be able to exercise the tab completion but not actually run any commands in the device.

#### How did you verify/test it?
Ran the test on the t0-8 and t1-8 topologies

#### Any platform specific information?
None

#### Supported testbed topology if it's a new test case?
Should work on any topology as this is just testing the Sonic CLI tab completion

### Documentation 
Added the command to the README.test.md file

#### Test Results

ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=sonic_cli_tab

"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=144  changed=9    unreachable=0    failed=2   

Thursday 22 August 2019  22:31:59 +0000 (0:00:00.076)       0:01:54.796 ******* 
=============================================================================== 
TASK: test : test the show commands ------------------------------------ 11.64s
TASK: test : test the clear commands ----------------------------------- 10.11s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.46s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.20s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.18s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.18s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.16s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.16s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.14s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.13s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.11s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.11s"

ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=sonic_cli_tab

"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=140  changed=9    unreachable=0    failed=2   

Thursday 22 August 2019  21:08:02 +0000 (0:00:00.074)       0:01:50.311 ******* 
=============================================================================== 
TASK: test : test the show commands ------------------------------------ 12.00s
TASK: test : test the clear commands ----------------------------------- 10.48s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.20s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.20s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.18s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.15s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.15s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.14s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.14s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.14s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.14s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.13s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.12s
TASK: test : Execute the command ""{{ command }}"" followed by [tab] [tab] --- 2.11s"

