### PR TITLE
lafe-76 final review of `cli_fuzz` test case

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -57,6 +57,12 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 - You might need to redeploy your VMs before you run this test due to the change for ToR VM router configuration changes
    `./testbed-cli.sh config-vm your-topo-name(vms1-1) your-vm-name(VM0108)` will do this for you
 
+##### CLI Fuzz test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=cli_fuzz -e testbed_name={TESTBED_NAME}
+```
+- Requires python to be installed on the DUT
+
 ##### Config test
 ```
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=config -e testbed_name={TESTBED_NAME}

--- a/ansible/roles/test/tasks/cli_fuzz.yml
+++ b/ansible/roles/test/tasks/cli_fuzz.yml
@@ -1,0 +1,61 @@
+- block:
+  - name: configure the settings for the test
+    set_fact:
+      sonic_show_commands:
+        - show
+        - show aaa
+        - show acl
+        - show arp
+        - show bgp
+        - show clock
+        - show ecn
+        - show environment
+        - show interfaces
+        - show ip
+        - show ipv6
+        - show line
+        - show lldp
+        - show logging
+        - show mac
+        - show mirror_session
+        - show mmu
+        - show ndp
+        - show ntp
+        - show pfc
+        - show platform
+        - show priority-group
+        - show processes
+        - show queue
+        - show reboot-cause
+        - show route-map
+        - show runningconfiguration
+        - show services
+        - show startupconfiguration
+        - show system-memory
+        - show tacacs
+        - show techsupport
+        - show uptime
+        - show users
+        - show version
+        - show vlan
+        - show warm_restart
+        - show watermark
+      sonic_crm_commands:
+        - crm
+        - crm resources
+        - crm summary
+        - crm thresholds
+      quantity_of_tests: 1
+      length: 5-10
+
+- name: run tests for the show command
+  include: cli_fuzz/cli_fuzz_commands.yml  command={{item}}
+  with_items: sonic_show_commands
+
+- name: run tests for the show command
+  include: cli_fuzz/cli_fuzz_commands.yml  command={{item}}
+  with_items: sonic_crm_commands
+
+- name: Verify the system is still operational
+  include: roles/test/tasks/base_sanity.yml
+

--- a/ansible/roles/test/tasks/cli_fuzz/cli_fuzz.py
+++ b/ansible/roles/test/tasks/cli_fuzz/cli_fuzz.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python2
+
+import argparse
+import random
+import string
+import subprocess
+import syslog
+
+
+# Function to create the fuzz commands to send to the cli
+def create_list_of_random_chars(items_in_list=1, min_string_length=10, string_length=10):
+    random_list = []
+
+    # Create the random fuzz commands for the sonic command
+    for i in range(items_in_list):
+        str_len = random.randint(min_string_length, string_length)
+        random_list.append(''.join(random.choice(string.printable) for i in range(str_len)))
+
+    return random_list
+
+
+def send_commands(base=None, repetitions=1, qty_of_sub_commands=1, sub_command_max_length=10, sub_command_min_length=None):
+    for i in range(repetitions):
+        fuzz_cmds = create_list_of_random_chars(items_in_list=qty_of_sub_commands,
+                                                min_string_length=sub_command_min_length,
+                                                string_length=sub_command_max_length)
+
+        # Run the command with the base and the fuzz commands
+        cmds = base + fuzz_cmds
+        syslog.syslog(str(cmds))
+        subprocess.call(cmds)
+
+
+def initialize_arg_parser():
+    # Returns a list of values containing the minimum and maximum values for the fuzz string length
+    def length_calc(value):
+        to_return = None
+        if "-" in value:
+            min, max = value.split("-")
+
+            if not min.isdigit() and not max.isdigit():
+                raise argparse.ArgumentError("You can only pass integers into the length field.  You passed in: {0} {1}".format(min, max))
+
+            if int(min) > int(max):
+                to_return = [int(max), int(min)]
+            else:
+                to_return = [int(min), int(max)]
+        elif not value.isdigit():
+            raise argparse.ArgumentError("You can only pass integers into the length field.  You passed in: {0}".format(value))
+
+        else:
+            to_return = [int(value), int(value)]
+
+        return to_return
+
+    description = 'Program to do cli fuzzing of the Sonic CLI commands'
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("-S", "--sonic_cmd", help="sonic command to test (Required)", action="store", nargs='*', required=True)
+    parser.add_argument("-C", "--sub_cmds", help="number of fake sub commands to create. (Default=1)", action="store", type=int, nargs=1, default=[1])
+    parser.add_argument("-Q", "--qty", help="number of times to fuzz the command (Default=10)", type=int, nargs=1, default=[10])
+
+    help_msg = "number of characters or a range of characters in the subcommand (Example=1-10) (Default=10)"
+    parser.add_argument("-L", "--length", help=help_msg, action="store", type=length_calc, nargs=1, default=[[10,10]])
+
+    return parser.parse_args()
+
+
+def main():
+    args = initialize_arg_parser()
+
+    # Pull the sonic commands to test out of the cli args
+    base_cmds = args.sonic_cmd
+    qty_sub_cmds = args.sub_cmds[0]
+    reps = args.qty[0]
+    length = args.length[0]
+
+    min_length = length[0]
+    max_length = length[1]
+
+    send_commands(base=base_cmds,
+                  repetitions=reps,
+                  qty_of_sub_commands=qty_sub_cmds,
+                  sub_command_max_length=max_length,
+                  sub_command_min_length=min_length)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/test/tasks/cli_fuzz/cli_fuzz_commands.yml
+++ b/ansible/roles/test/tasks/cli_fuzz/cli_fuzz_commands.yml
@@ -1,0 +1,17 @@
+- block:
+  - name: Send fuzz script to the remote device with a single fuzz subcommand
+    script: roles/test/tasks/cli_fuzz/cli_fuzz.py --sonic_cmd {{ command }} --sub_cmds 1 --qty {{ quantity_of_tests }} --length {{ length }} 
+
+  - name: Send fuzz script to the remote device with two fuzz subcommands
+    script: roles/test/tasks/cli_fuzz/cli_fuzz.py --sonic_cmd {{ command }} --sub_cmds 2 --qty {{ quantity_of_tests }} --length {{ length }} 
+
+  - name: Send fuzz script to the remote device with three fuzz subcommands
+    script: roles/test/tasks/cli_fuzz/cli_fuzz.py --sonic_cmd {{ command }} --sub_cmds 3 --qty {{ quantity_of_tests }} --length {{ length }} 
+
+  - name: Send fuzz script to the remote device with four fuzz subcommands
+    script: roles/test/tasks/cli_fuzz/cli_fuzz.py --sonic_cmd {{ command }} --sub_cmds 4 --qty {{ quantity_of_tests }} --length {{ length }} 
+
+  - name: Send fuzz script to the remote device with five fuzz subcommands
+    script: roles/test/tasks/cli_fuzz/cli_fuzz.py --sonic_cmd {{ command }} --sub_cmds 5 --qty {{ quantity_of_tests }} --length {{ length }} 
+
+

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -34,6 +34,10 @@ testcases:
           ptf_host:
           testbed_type:
 
+    cli_fuzz:
+      filename: cli_fuzz.yml
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t1]
+
     config:
         filename: config.yml
         topologies: [t1-lag, t1-64-lag, t0, t0-64, t0-116]


### PR DESCRIPTION
### Description of PR

Summary:
This adds a python script that will do cli fuzzing.  It then includes an ansible script to call the python script for any number of cli commands to be fuzzed.  It then calls each of those commands with a different number of sub commands.

The test fails if the system becomes unstable and fails the `base_sanity` test or for some reason stops being able to run additional fuzzing commands.

The list of commands that is sent to the DUT is also logged to the syslog in case it becomes necessary to determine which commands broke the system. 

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Created a python script that accepts cli arguments to define which commands to fuzz, how many fuzz sub commands, and length of the command.

#### How did you verify/test it?
I ran it using the t0-8 and t1-8 topologies and the tests passed

#### Any platform specific information?
Platform must have python.  Tested with python2 but would probably work with python3.

#### Supported testbed topology if it's a new test case?
t0 or t1 based topologies should work.

### Documentation 
Updated the readme file with instructions on how to run the test.

##### Test Results

Command: ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=cli_fuzz

Results:
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=303  changed=220  unreachable=0    failed=0   

Sunday 01 September 2019  00:43:57 +0000 (0:00:00.089)       0:06:16.187 ****** 
=============================================================================== 
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand -- 44.06s
TASK: test : run tests for the show command ---------------------------- 18.44s
TASK: test : run tests for the show command ---------------------------- 10.28s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 4.01s
TASK: test : Verify the system is still operational --------------------- 3.60s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 2.05s
TASK: test : Send fuzz script to the remote device with four fuzz subcommands --- 2.05s
TASK: test : Send fuzz script to the remote device with two fuzz subcommands --- 2.02s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 2.02s
TASK: test : Verify port channel interfaces are up correctly ------------ 1.93s
TASK: test : gather system version information -------------------------- 1.71s
TASK: test : Send fuzz script to the remote device with five fuzz subcommands --- 1.58s
TASK: test : validate all interfaces are up after test ------------------ 1.46s
TASK: test : Send fuzz script to the remote device with four fuzz subcommands --- 1.45s
TASK: test : Send fuzz script to the remote device with five fuzz subcommands --- 1.42s
TASK: test : Send fuzz script to the remote device with four fuzz subcommands --- 1.42s
TASK: test : Send fuzz script to the remote device with three fuzz subcommands --- 1.41s
TASK: test : Send fuzz script to the remote device with three fuzz subcommands --- 1.41s
TASK: test : Send fuzz script to the remote device with three fuzz subcommands --- 1.41s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.41s"

command: ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=cli_fuzz

results:
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=299  changed=220  unreachable=0    failed=0   

Sunday 01 September 2019  02:05:44 +0000 (0:00:00.072)       0:05:29.286 ****** 
=============================================================================== 
TASK: test : run tests for the show command ---------------------------- 18.59s
TASK: test : run tests for the show command ---------------------------- 10.37s
TASK: test : Verify the system is still operational --------------------- 3.61s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 2.09s
TASK: test : Send fuzz script to the remote device with three fuzz subcommands --- 2.09s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 2.05s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.74s
TASK: test : gather system version information -------------------------- 1.73s
TASK: test : Send fuzz script to the remote device with two fuzz subcommands --- 1.60s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.52s
TASK: test : Send fuzz script to the remote device with two fuzz subcommands --- 1.50s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.49s
TASK: test : Send fuzz script to the remote device with five fuzz subcommands --- 1.46s
TASK: test : validate all interfaces are up after test ------------------ 1.45s
TASK: test : Send fuzz script to the remote device with two fuzz subcommands --- 1.41s
TASK: test : Send fuzz script to the remote device with four fuzz subcommands --- 1.40s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.39s
TASK: test : Send fuzz script to the remote device with four fuzz subcommands --- 1.39s
TASK: test : Send fuzz script to the remote device with two fuzz subcommands --- 1.38s
TASK: test : Send fuzz script to the remote device with a single fuzz subcommand --- 1.38s"


