### PR TITLE
lafe-77 final review of arp/ndp clear tests

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -42,6 +42,12 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ```
 - Requires switch connected to a PTF testbed
 
+##### ARP Clear test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=arp_clear -e testbed_name={TESTBED_NAME}
+```
+- Requires a PTF on the testbed
+
 ##### BGP facts verification test
 ```
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=bgp_fact -e testbed_name={TESTBED_NAME}
@@ -197,6 +203,11 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=mtu -e testbed_name={TESTBED_NAME}
 ```
 - Requires switch connected to PTF testbed
+
+##### NDP Clear test
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=ndp_clearz -e testbed_name={TESTBED_NAME}
+```
 
 ##### Neighbor Mac test
 ```

--- a/ansible/library/parse_text_table.py
+++ b/ansible/library/parse_text_table.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+---
+module:  parse_text_table
+version_added:  "2.0"
+author: Joe Lazaro (@joeslazaro)
+short_description: Parse a text table and convert it to a dict or list of dicts
+description: |
+    Expects a text table with with fixed-width columns and '-' 
+    characters as separators between the column headers and the data. It will
+    product a list of dicts corresponding to each row of data. It will also
+    create a dictionary keyed by the value of the first column, so you can
+    choose the most convenient return value type to process the result. 
+    
+    Note: If the first column of a table row is empty, then that row will not
+    currently be stored in the parsed_table_dict return value, so be careful if
+    that is a possibility. 
+Options:
+    - option-name: text
+      description: The text table to be parsed
+      required: True
+      Default: None
+'''
+
+EXAMPLES = '''
+- name: Extract the IP interfaces table from a previous command's output
+  parse_text_table:
+    text: my_registered_var.stdout
+    return_as: 'dict'
+'''
+
+RETURN = '''
+parsed_table_list:
+    description: A list of dictionaries containing each values for table row
+    returned: always
+    type: list
+
+parsed_table_dict:
+    description: A dictionary of table row values, keyed by the first column
+    returned: always
+    type: dict
+'''
+
+
+def parse_text_table(text):
+    """Extract a table based on fixed-width columns from a block of text
+
+    Arguments:
+        text: Text table to be parsed
+
+    This uses a table header separator to determine column widths, then
+    captures the appropriate number of characters for each column until an
+    empty line is reached.
+
+    Example input text:
+
+    admin@lab-ignw-seastone-dut-li1:~$ show ip interfaces
+    Interface        IPv4 address/mask    Admin/Oper
+    ---------------  -------------------  ------------
+    PortChannel0001  10.0.0.56/31         up/up
+    PortChannel0002  10.0.0.58/31         up/up
+    PortChannel0003  10.0.0.60/31         up/up
+    PortChannel0004  10.0.0.62/31         up/up
+    Vlan1000         192.168.0.1/21       up/up
+    docker0          240.127.1.1/24       up/down
+    eth0             10.50.0.8/22         up/up
+    lo               127.0.0.1/8          up/up
+    """
+
+    re_separator_line = re.compile(r'(\s*-+)+')
+    re_column = re.compile('\s*-+')
+    headers = None
+    row_pattern = None
+    prev_row = None
+    result_rows = []
+    result_dict = {}
+
+    for line in text.splitlines():
+        if re_separator_line.match(line):
+            if headers is not None:
+                break   # Found table footer
+
+            # Create a regex pattern to capture each column (by width)
+            pattern_pieces = []
+            for col_match in re_column.finditer(line):
+                col_width = len(col_match.group())
+                pattern_pieces.append('(.{0,' + str(col_width) + '})')
+            row_pattern = ''.join(pattern_pieces)
+
+            # Look at the row above the separator and capture the header text
+            # to be used as dictionary keys for each column value
+            match = re.match(row_pattern, prev_row)
+            if match:
+                headers = list(map(str.strip, match.groups()))
+                # print("Found text table headers:{}".format(headers))
+            else:
+                err_msg = "Failed parsing headers from line:{}".format(prev_row)
+                raise ValueError(err_msg)
+        elif headers is None:
+            pass  # Ignoring line because no header seen yet
+        elif len(line.strip()) == 0:
+            break  # Found end of data (blank line)
+        else:
+            match = re.match(row_pattern, line)
+            if match:
+                cols = list(map(str.strip, match.groups()))
+                row_dict = {}
+                for index, col in enumerate(cols):
+                    row_dict[headers[index]] = col
+                # Store the row in both the list and dictionary return values
+                result_rows.append(row_dict)
+                key = row_dict[headers[0]]
+                if len(key.strip()) > 0:
+                    result_dict[key] = row_dict
+            # else:
+            #     logger.trace('Table line did not match the pattern:' + line)
+
+        prev_row = line
+    return result_rows, result_dict
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            text=dict(required=True, type='str'),
+        ),
+        supports_check_mode=False)
+
+    p = module.params
+    list_result, dict_result = parse_text_table(p['text'])
+    module.exit_json(ansible_facts={
+        'parsed_table_list': list_result,
+        'parsed_table_dict': dict_result})
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/parse_text_table.py
+++ b/ansible/library/parse_text_table.py
@@ -10,7 +10,7 @@ short_description: Parse a text table and convert it to a dict or list of dicts
 description: |
     Expects a text table with with fixed-width columns and '-' 
     characters as separators between the column headers and the data. It will
-    product a list of dicts corresponding to each row of data. It will also
+    produce a list of dicts corresponding to each row of data. It will also
     create a dictionary keyed by the value of the first column, so you can
     choose the most convenient return value type to process the result. 
     

--- a/ansible/roles/test/files/ptftests/arp_clear.py
+++ b/ansible/roles/test/files/ptftests/arp_clear.py
@@ -1,0 +1,56 @@
+import os
+import ptf
+from ptf.testutils import *
+from ptf import config
+from ptf.base_tests import BaseTest
+
+
+class ACSDataplaneTest(BaseTest):
+    def setUp(self):
+        BaseTest.setUp(self)
+
+        self.test_params = test_params_get()
+        print "You specified the following test-params when invoking ptf:"
+        print self.test_params
+
+        # shows how to use a filter on all our tests
+        add_filter(not_ipv6_filter)
+
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+        if config["log_dir"] != None:
+            filename = os.path.join(config["log_dir"], str(self)) + ".pcap"
+            self.dataplane.start_pcap(filename)
+
+    def tearDown(self):
+        if config["log_dir"] != None:
+            self.dataplane.stop_pcap()
+        reset_filters()
+        BaseTest.tearDown(self)
+
+
+class VerifyUnicastARPReply(ACSDataplaneTest):
+    """Send a unicast ARP request so that the peer adds the desired ARP entry"""
+
+    def runTest(self):
+        acs_mac = self.test_params['acs_mac']
+        pkt = simple_arp_packet(
+            eth_dst=acs_mac,
+            eth_src=self.test_params['fake_mac'],
+            arp_op=1,
+            ip_snd=self.test_params['fake_ip'],
+            ip_tgt=self.test_params['dut_ip'],
+            hw_snd=self.test_params['fake_mac'],
+            hw_tgt=acs_mac,
+        )
+        exp_pkt = simple_arp_packet(
+            eth_dst=self.test_params['fake_mac'],
+            eth_src=acs_mac,
+            arp_op=2,
+            ip_snd=self.test_params['dut_ip'],
+            ip_tgt=self.test_params['fake_ip'],
+            hw_tgt=self.test_params['fake_mac'],
+            hw_snd=acs_mac,
+        )
+        send_packet(self, self.test_params['port'], pkt)
+        verify_packet(self, exp_pkt, self.test_params['port'])

--- a/ansible/roles/test/tasks/arp_clear.yml
+++ b/ansible/roles/test/tasks/arp_clear.yml
@@ -1,0 +1,151 @@
+######################################################################
+## This playbook tests that we are able to clear ARP entries using the
+## sonic-clear utility.
+######################################################################
+
+- name: Define some common test values
+  set_fact:
+    dut_ip: "10.10.1.2"
+    dut_prefixlen: "28"
+    arp_test_data:
+      - fake_mac: "00:06:07:08:09:00"
+        fake_ip: "10.10.1.3"
+      - fake_mac: "00:06:07:08:09:01"
+        fake_ip: "10.10.1.4"
+      - fake_mac: "00:06:07:08:09:02"
+        fake_ip: "10.10.1.5"
+
+- block:
+    - name: gather interface information if not available
+      interface_facts:
+      when: ansible_interface_facts is not defined
+
+    - name: Read the current interfaces status
+      shell: show interfaces status | head
+      register: show_interface_status
+
+    - name: Extract the interfaces table from a previous command's output
+      parse_text_table:
+        text: "{{ show_interface_status.stdout }}"
+
+    - name: Find non-trunk interfaces
+      set_fact: candidate_ports="{{ candidate_ports|default([]) + [item] }}"
+      with_items: "{{ minigraph_ports }}"
+      when: parsed_table_dict[item]['Vlan'] != "trunk"
+
+    - name: Choose the first candidate port for testing
+      set_fact:
+        test_interface: "{{ candidate_ports[0] }}"
+
+    - name: figure out selected interface index
+      set_fact:
+        test_interface_index: "{{ minigraph_port_indices[test_interface] }}"
+
+    - name: find if interface1 in portchannel
+      set_fact:
+        po1: "{{ item.key }}"
+      when: test_interface in item.value['members']
+      with_dict: minigraph_portchannels
+
+    - name: move interface {{ test_interface }} out of {{ po1 }}
+      shell: teamdctl {{ po1 }} port remove {{ test_interface }}
+      become: yes
+      when: po1 is defined
+
+    - name: bring {{ test_interface }} up
+      shell: config interface startup {{ test_interface }}
+      become: yes
+      when: po1 is defined
+
+    - name: change SONiC DUT interface IP to test IP address
+      command: config interface ip add {{ test_interface }} {{ dut_ip }}/{{ dut_prefixlen}}
+      become: yes
+
+    - name: wait for interfaces to be up after removed from portchannel
+      pause: seconds=40
+      when: (po1 is defined) or (po2 is defined)
+
+    - name: copy test files over
+      copy: src=roles/test/files/ptftests dest=/root
+      delegate_to: "{{ ptf_host }}"
+
+    - name: Start PTF runner and send unicast arp packets using arp_test_data
+      include: ptf_runner.yml
+      vars:
+        ptf_test_name: ARP test
+        ptf_test_dir: ptftests
+        ptf_test_path: arp_clear.VerifyUnicastARPReply
+        ptf_platform: remote
+        ptf_platform_dir: ptftests
+        ptf_test_params:
+          - acs_mac='{{ ansible_interface_facts[test_interface]['macaddress'] }}'
+          - port='{{ test_interface_index }}'
+          - fake_mac='{{ item.fake_mac }}'
+          - fake_ip='{{ item.fake_ip }}'
+          - dut_ip='{{ dut_ip }}'
+        ptf_extra_options: "--relax --debug info --log-file /tmp/arp_clear.VerifyUnicastARPReply.{{lookup('pipe','date +%Y-%m-%d-%H:%M:%S')}}.log "
+      with_list: arp_test_data
+
+    - name: Get DUT arp table
+      switch_arptable:
+
+    - name: Check SONiC ARP table and confirm that expected entries are present
+      assert:
+        that:
+          - "{{ item.fake_ip in arptable['v4'].keys() }}"
+          - "{{ arptable['v4'][item.fake_ip]['macaddress'] == item.fake_mac }}"
+          - "{{ arptable['v4'][item.fake_ip]['interface'] == test_interface }}"
+      with_list: arp_test_data
+
+    - name: Clear the first test ARP entry
+      shell: sonic-clear arp {{ arp_test_data[0].fake_ip }}
+
+    - name: Get the latest ARP table entries
+      switch_arptable:
+
+    - name: Check SONiC ARP table and confirm that the entry was removed
+      assert:
+        that:
+          - "{{ arptable['v4'][arp_test_data[0].fake_ip]['macaddress'] == 'None' }}"
+
+    - name: Confirm that the rest of the test ARP entries are still present
+      assert:
+        that:
+          - "{{ item.fake_ip in arptable['v4'].keys() }}"
+          - "{{ arptable['v4'][item.fake_ip]['macaddress'] == item.fake_mac }}"
+          - "{{ arptable['v4'][item.fake_ip]['interface'] == test_interface }}"
+      with_list: arp_test_data[1:]
+
+    - name: Clear the all ARP entries
+      shell: sonic-clear arp
+
+    - name: Get the latest ARP table entries
+      switch_arptable:
+
+    - name: Confirm that all of the test ARP entries are gone
+      assert:
+        that:
+          - "{{ arptable['v4'][arp_test_data[0].fake_ip]['macaddress'] == 'None' }}"
+      with_list: arp_test_data[1:]
+
+  always:
+    # Recover DUT interface IP Address before entering this test case
+    - name: restore dut original state
+      include: "roles/test/tasks/common_tasks/reload_config.yml"
+      vars:
+        config_source: "config_db"
+
+    - name: check port status
+      interface_facts: up_ports={{ minigraph_ports }}
+
+    - name: wait again if still not up
+      pause: seconds=30
+      when: ansible_interface_link_down_ports | length != 0
+
+    - name: second chance to check
+      interface_facts: up_ports={{ minigraph_ports }}
+      when: ansible_interface_link_down_ports | length != 0
+
+    - name: last wait if still not up
+      pause: seconds=30
+      when: ansible_interface_link_down_ports | length != 0

--- a/ansible/roles/test/tasks/ndp_clear.yml
+++ b/ansible/roles/test/tasks/ndp_clear.yml
@@ -1,0 +1,29 @@
+######################################################################
+## This playbook tests that we are able to clear NDP entries using the
+## sonic-clear utility. PTF doesn't support generating NDP packets, so
+## we rely on their being existing entries from the switch's neighbors
+######################################################################
+
+- name: Show NDP table and get the number of entries
+  shell: show ndp | grep "Total number of entries" | grep -o -E '[0-9]+'
+  register: ndp_original
+  failed_when: ndp_original.stdout|int <= 0
+
+- debug:
+    msg: "Found {{ ndp_original.stdout|int }} NDP entries"
+
+## Note: We can't check for zero entries after doing a clear since some
+## of the entries will come back too fast.
+- name: Clear all NDP entries
+  shell: sonic-clear ndp
+
+- name: Show NDP table and get the number of entries
+  shell: show ndp | grep "Total number of entries" | grep -o -E '[0-9]+'
+  register: ndp_cleared
+
+- debug:
+    msg: "Found {{ ndp_cleared.stdout|int }} NDP entries"
+
+- name: Verify that the number of entries has decreased
+  assert:
+    that: ndp_cleared.stdout|int < ndp_original.stdout|int

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -12,6 +12,10 @@ testcases:
       required_vars:
           ptf_host:
 
+    arp_clear:
+      filename: arp_clear.yml
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
+
     bgp_fact:
       filename: bgp_fact.yml
       topologies: [t0, t0-16, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag]
@@ -166,6 +170,10 @@ testcases:
       required_vars:
           ptf_host:
           testbed_type:
+
+    ndp_clear:
+      filename: ndp_clear.yml
+      topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
     neighbour:
       filename: neighbour-mac.yml


### PR DESCRIPTION
### Description of PR


Summary:
Adds a test to verify the ARP and NDP tables can be cleared and repopulated.

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
For the `arp_clear` command, use the PTF to send ARP packets and verify they are received.

for the `ndp_clear` due to ipv6, can only clear the table and verify it gets repopulated.

#### How did you verify/test it?
Ran the test on the t0-8 and the t1-8 topologies and they passed

#### Any platform specific information?
Requires a PTF for the `arp_clear` test

#### Supported testbed topology if it's a new test case?
t0 and t1 topologies with a PTF should work

### Documentation 
Updated the readme with instructions on how to run the command

### Test Results
Command: ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=arp_clear

Results: 
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=89   changed=17   unreachable=0    failed=0   

Sunday 01 September 2019  00:50:22 +0000 (0:00:00.077)       0:05:18.527 ****** 
=============================================================================== 
TASK: test : Wait for 2 minutes for prcesses and interfaces to be stable - 120.15s
TASK: test : Reload SONiC configuration using config_db ---------------- 90.12s
TASK: test : wait for interfaces to be up after removed from portchannel -- 40.13s
TASK: test : copy test files over --------------------------------------- 3.81s
TASK: test : Find non-trunk interfaces ---------------------------------- 3.29s
TASK: test : Verify port channel interfaces are up correctly ------------ 2.37s
TASK: test : Start PTF runner and send unicast arp packets using arp_test_data --- 2.31s
TASK: test : validate all interfaces are up after test ------------------ 1.98s
TASK: test : find if interface1 in portchannel -------------------------- 1.72s
TASK: test : Read the current interfaces status ------------------------- 1.71s
TASK: test : gather system version information -------------------------- 1.70s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.49s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.48s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.48s
TASK: test : debug ------------------------------------------------------ 1.47s
TASK: test : debug ------------------------------------------------------ 1.46s
TASK: test : debug ------------------------------------------------------ 1.45s
TASK: test : command ---------------------------------------------------- 1.35s
TASK: test : command ---------------------------------------------------- 1.25s
TASK: setup ------------------------------------------------------------- 1.20s"

Command:
ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=arp_clear

Results:
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=81   changed=16   unreachable=0    failed=0   

Sunday 01 September 2019  02:29:13 +0000 (0:00:00.076)       0:04:31.469 ****** 
=============================================================================== 
TASK: test : Wait for 2 minutes for prcesses and interfaces to be stable - 120.17s
TASK: test : Reload SONiC configuration using config_db ---------------- 89.29s
TASK: test : copy test files over --------------------------------------- 4.14s
TASK: test : Find non-trunk interfaces ---------------------------------- 3.52s
TASK: test : Start PTF runner and send unicast arp packets using arp_test_data --- 2.25s
TASK: test : validate all interfaces are up after test ------------------ 1.98s
TASK: test : gather system version information -------------------------- 1.72s
TASK: test : Read the current interfaces status ------------------------- 1.62s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.51s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.48s
TASK: test : debug ------------------------------------------------------ 1.48s
TASK: test : debug ------------------------------------------------------ 1.47s
TASK: test : Fetch result files from switch to ansible machine ---------- 1.47s
TASK: test : debug ------------------------------------------------------ 1.47s
TASK: setup ------------------------------------------------------------- 1.33s
TASK: test : command ---------------------------------------------------- 1.30s
TASK: test : command ---------------------------------------------------- 1.24s
TASK: test : command ---------------------------------------------------- 1.23s
TASK: test : Reload SONiC configuration using minigraph ----------------- 1.16s
TASK: test : check port status ------------------------------------------ 1.14s"


Command:
ansible-playbook -i lab test_sonic.yml -e testbed_name=t0-eight -e testcase_name=ndp_clear

Results:
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=49   changed=10   unreachable=0    failed=0   

Sunday 01 September 2019  00:52:37 +0000 (0:00:00.079)       0:00:29.441 ****** 
=============================================================================== 
TASK: test : Verify port channel interfaces are up correctly ------------ 1.93s
TASK: test : gather system version information -------------------------- 1.69s
TASK: test : Show NDP table and get the number of entries --------------- 1.59s
TASK: test : Show NDP table and get the number of entries --------------- 1.55s
TASK: test : validate all interfaces are up after test ------------------ 1.50s
TASK: setup ------------------------------------------------------------- 1.14s
TASK: test : Verify port channel interfaces are up correctly ------------ 1.13s
TASK: test : Get interface facts ---------------------------------------- 0.95s
TASK: test : Get interface facts ---------------------------------------- 0.94s
TASK: test : validate all interfaces are up ----------------------------- 0.86s
TASK: test : Get process information in syncd docker -------------------- 0.83s
TASK: test : Get process information in syncd docker -------------------- 0.76s
TASK: test : do basic sanity check after each test ---------------------- 0.68s
TASK: test : Gathering minigraph facts about the device ----------------- 0.65s
TASK: test : Gather minigraph facts about the device -------------------- 0.60s
TASK: test : Clear all NDP entries -------------------------------------- 0.60s
TASK: test : Gather minigraph facts about the device -------------------- 0.59s
TASK: test : Get syslog error information ------------------------------- 0.58s
TASK: test : Get syslog error information ------------------------------- 0.55s
TASK: test : Verify VLAN interfaces are up correctly -------------------- 0.54s"

Command:
ansible-playbook -i lab test_sonic.yml -e testbed_name=t1-eight -e testcase_name=ndp_clear

Results:
"PLAY RECAP *********************************************************************
lab-ignw-seastone-dut-li1  : ok=45   changed=10   unreachable=0    failed=0   

Sunday 01 September 2019  02:07:58 +0000 (0:00:00.078)       0:00:26.136 ****** 
=============================================================================== 
TASK: test : gather system version information -------------------------- 1.72s
TASK: test : Show NDP table and get the number of entries --------------- 1.59s
TASK: test : validate all interfaces are up after test ------------------ 1.59s
TASK: test : Show NDP table and get the number of entries --------------- 1.55s
TASK: setup ------------------------------------------------------------- 1.13s
TASK: test : Get interface facts ---------------------------------------- 0.96s
TASK: test : Get interface facts ---------------------------------------- 0.93s
TASK: test : validate all interfaces are up ----------------------------- 0.92s
TASK: test : Get process information in syncd docker -------------------- 0.91s
TASK: test : Get process information in syncd docker -------------------- 0.77s
TASK: test : do basic sanity check after each test ---------------------- 0.73s
TASK: test : Gather minigraph facts about the device -------------------- 0.62s
TASK: test : Gather minigraph facts about the device -------------------- 0.62s
TASK: test : Clear all NDP entries -------------------------------------- 0.62s
TASK: test : Gathering minigraph facts about the device ----------------- 0.58s
TASK: test : do basic sanity check before each test --------------------- 0.47s
TASK: test : Gathering testbed information ------------------------------ 0.44s
TASK: test : Get orchagent process information -------------------------- 0.44s
TASK: test : Get syslog error information ------------------------------- 0.43s
TASK: test : run test case {{ testcases[testcase_name]['filename'] }} file --- 0.38s"

