### PR TITLE
adding import statments and fixing print statments to fix python2/3 i…

### DIFF
--- a/ansible/roles/test/files/ptftests/arp_clear.py
+++ b/ansible/roles/test/files/ptftests/arp_clear.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import absolute_import
+
 import os
 import ptf
 from ptf.testutils import *
@@ -10,8 +13,8 @@ class ACSDataplaneTest(BaseTest):
         BaseTest.setUp(self)
 
         self.test_params = test_params_get()
-        print "You specified the following test-params when invoking ptf:"
-        print self.test_params
+        print("You specified the following test-params when invoking ptf:")
+        print(self.test_params)
 
         # shows how to use a filter on all our tests
         add_filter(not_ipv6_filter)


### PR DESCRIPTION
Changed the print statements to be python3 compatible and added the import statements to get pylint to not complain.  

Also ran the test and it passed.

Attaching results of pylint

[pylint_arp_clear_output.txt](https://github.com/IGNW/sonic-mgmt/files/3576903/pylint_arp_clear_output.txt)
