### PR TITLE
Update incremental config to use active interfaces

### DIFF
--- a/ansible/roles/test/tasks/incremental_config.yml
+++ b/ansible/roles/test/tasks/incremental_config.yml
@@ -19,7 +19,7 @@
 - name: verify that there are at least 2 interfaces that we can test with
   assert:
     that: (test_interfaces | length) >= 2
-    msg: This test requires at two active Ethernet interfaces
+    msg: This test requires at least two active Ethernet interfaces
 
 - name: Add and remove an IPv4 address from an interface
   include: incremental_config/incremental_config_ip.yml

--- a/ansible/roles/test/tasks/incremental_config.yml
+++ b/ansible/roles/test/tasks/incremental_config.yml
@@ -5,56 +5,56 @@
 
 - name: set initial variables
   set_fact:
-    inactive_eth_iface_list: []
-    ethernet_portchannel_interfaces: []
     test_ipv4_address: 10.200.4.5/24
     test_ipv6_address: fc00::aa07/126
     test_port_channel_name: PortChannel0999
     test_vlan: 999
 
-- name: create inactive interface list
+- name: Get a list of active Ethernet interface names
   set_fact:
-    inactive_eth_iface_list: "{{ inactive_eth_iface_list }} + ['{{ item.device }}']"
-  when: item.active == false and "Ethernet" in item.device 
+    test_interfaces: "{{ test_interfaces|default([]) }} + ['{{ item.device }}']"
+  when: item.active == True and "Ethernet" in item.device
   with_items: "{{ ansible_interface_facts.values() }}"
 
-- name: verify that there are at least 4 inactive interfaces
+- name: verify that there are at least 2 interfaces that we can test with
   assert:
-    that: (inactive_eth_iface_list | length) >= 4
-    msg: This test requires at least four inactive Ethernet interfaces
+    that: (test_interfaces | length) >= 2
+    msg: This test requires at two active Ethernet interfaces
 
-- name: set test interface variable
-  set_fact:
-    test_ip_iface: "{{ inactive_eth_iface_list[0] }}"
-    test_vlan_iface: "{{ inactive_eth_iface_list[-1] }}" 
-    test_portchannel_members: ["{{ inactive_eth_iface_list[-2] }}","{{ inactive_eth_iface_list[-3] }}"]
+- name: Add and remove an IPv4 address from an interface
+  include: incremental_config/incremental_config_ip.yml
+  vars:
+    ip_type: 'ipv4'
+    address: "{{ test_ipv4_address }}"
+    interface: "{{ test_interfaces[0] }}"
 
-- name: "Ansible | List all known variables and facts"
-  debug:
-    var: "{{ item }}"
-  with_items:
-    - inactive_eth_iface_list 
-    - test_ip_iface
-    - test_vlan_iface
-    - test_portchannel_members
+- name: Add and remove an IPv6 address from an interface
+  include: incremental_config/incremental_config_ip.yml
+  vars:
+    ip_type: 'ipv6'
+    address: "{{ test_ipv6_address }}"
+    interface: "{{ test_interfaces[0] }}"
 
-# Add and remove an ipv4 address from an interface
-- name: run ipv4 tests
-  include: incremental_config/incremental_config_ip.yml address={{test_ipv4_address}} interface={{test_ip_iface}} ip_type='ipv4' 
+- name: Add and remove VLAN membership from an interface
+  include: incremental_config/incremental_config_vlan.yml
+  vars:
+    interface: "{{ test_interfaces[0] }}"
 
-# Add and remove an ipv6 address from an interface
-- name: run ipv6 tests
-  include: incremental_config/incremental_config_ip.yml address={{test_ipv6_address}} interface={{test_ip_iface}} ip_type='ipv6' 
+- name: Add and remove a portchannel interface
+  include: incremental_config/incremental_config_portchannel.yml
+  vars:
+    name: "{{ test_port_channel_name }}"
+    members: "{{ test_interfaces[:2] }}"
 
-# Add and remove a vlan from an interface
-- name: run vlan tests
-  include: incremental_config/incremental_config_vlan.yml vlan={{test_vlan}} interface={{test_vlan_iface}}
-
-# Add and remove a portchannel to the switch
-- name: run portchannel tests
-  include: incremental_config/incremental_config_portchannel.yml name={{test_port_channel_name}} members={{test_portchannel_members}}
-
-# Add and remove some acl rules via the incremental updated command
-- name: run acl update tests
+- name: Add and remove some acl rules via the incremental updated command
   include: incremental_config/incremental_config_acl_incremental_update.yml
 
+- name: Do basic sanity check and allow recovery
+  include: base_sanity.yml
+  vars:
+    recover: "{{ allow_recover }}"
+
+- name: Validate all interfaces are up and allow recovery
+  include: interface.yml
+  vars:
+    recover: "{{ allow_recover }}"

--- a/ansible/roles/test/tasks/incremental_config/incremental_config_ip.yml
+++ b/ansible/roles/test/tasks/incremental_config/incremental_config_ip.yml
@@ -27,7 +27,7 @@
 
     - name: verify that the IP shows up in the output 
       assert:
-        that:  out.stdout | search(address)
+        that: out.stdout | search(address)
 
     - name: remove IP from the interface
       shell: config interface ip remove {{ interface }} {{ address }}
@@ -39,10 +39,9 @@
 
     - name: verify that the IP does not show up in the output 
       assert:
-        that:  not out.stdout
+        that: not out.stdout | search(address)
 
   rescue:
     - name: remove IP from the interface on failure
       shell: config interface ip remove {{ interface }} {{ address }}
       become: yes
-

--- a/ansible/roles/test/tasks/incremental_config/incremental_config_portchannel.yml
+++ b/ansible/roles/test/tasks/incremental_config/incremental_config_portchannel.yml
@@ -17,7 +17,7 @@
 
     - name: verify that the portchannel shows up in the output 
       assert:
-        that:  out.stdout | search( name )
+        that: out.stdout | search(name)
 
     - name: add members to the portchannel
       shell: config portchannel member add {{ name }} {{ item }}
@@ -30,7 +30,7 @@
     
     - name: verify that the members show up in the output 
       assert:
-        that:  out.stdout | search( item )
+        that: out.stdout | search(item)
       with_items: members 
 
     - name: pull out lines from output for the portchannel ports
@@ -85,4 +85,3 @@
       shell: config portchannel del {{ name }} 
       become: yes
       when: name in out.stdout
-

--- a/ansible/roles/test/tasks/incremental_config/incremental_config_vlan.yml
+++ b/ansible/roles/test/tasks/incremental_config/incremental_config_vlan.yml
@@ -1,60 +1,44 @@
+# Test the CLI commands to add/remove VLAN membership from an interface
 - debug: msg="Starting vlan incremental config test"
 
-# Add and remove a vlan, add and remove a member
 - block:
     - name: add vlan
-      shell: config vlan add {{ vlan }}
+      shell: config vlan add {{ test_vlan }}
       become: yes
     
     - name: confirm vlan was added 
       shell: show vlan brief 
       register: out
+      failed_when: not out.stdout | search(test_vlan | string)
 
-    - name: verify that the vlan was added 
-      assert:
-        that: out.stdout | search(test_vlan | string)
-
-    - name: add the vlan to an interface
-      shell: config vlan member add {{ vlan }} {{ interface }}
+    - name: Make the test interface a member of the VLAN
+      shell: config vlan member add {{ test_vlan }} {{ interface }}
       become: yes
 
-    - name: confirm vlan was member was added to the vlan
-      shell: show vlan config
+    - name: Verify that the test interface is a member of the VLAN
+      shell: show vlan config | grep Vlan{{ test_vlan }}
       register: out
+      failed_when: not out.stdout | search(interface)
 
-    - name: verify that the member was added 
-      assert:
-        that: out.stdout | search(test_vlan | string)
-        that: out.stdout | search(test_vlan_iface)
-
-    - name: remove the vlan from the interface
-      shell: config vlan member del {{ vlan }} {{ interface }}
+    - name: Remove the VLAN membership from the test interface
+      shell: config vlan member del {{ test_vlan }} {{ interface }}
       become: yes
 
-    - name: confirm vlan was member was removed from the vlan
-      shell: show vlan config
+    - name: Verify that the test interface is not a member of the VLAN
+      shell: show vlan config | grep Vlan{{ test_vlan }}
       register: out
+      failed_when: out.stdout | search(interface)
 
-    - name: verify that the member was removed 
-      assert:
-        that: not out.stdout | search(test_vlan | string)
-        that: not out.stdout | search(test_vlan_iface)
-
-    - name: remove vlan 
-      shell: config vlan del {{ vlan }}
+    - name: Remove the VLAN
+      shell: config vlan del {{ test_vlan }}
       become: yes
     
-    - name: confirm vlan was deleted 
+    - name: Confirm that the VLAN was deleted
       shell: show vlan brief 
       register: out
-
-    - name: verify that the vlan does not show up in the output 
-      assert:
-        that:  not out.stdout | search(test_vlan | string) 
+      failed_when: out.stdout | search(test_vlan | string)
 
   rescue:
-    - name: remove vlan and member from the interface on failure
-      shell: config vlan del {{ vlan }}
+    - name: Remove the VLAN
+      shell: config vlan del {{ test_vlan }}
       become: yes
-
-


### PR DESCRIPTION
On a full topology, there probably won't even be inactive interfaces, so I changed the code to use active interfaces. I also simplified it a bit by removing some assert statements and adding in the logic to failed_when statements in the previous task. 

I noticed on multiple occasions after/during that the syncd container had stopped. The updated code has a health check recovery option to get the switch back to a working state.

The tests passed except for the Portchannel test. I tried the commands manually and the switch is not actually putting the interfaces I add into the portchannel. I looked at examples online and tried other verification commands and it seems like the switch is just misbehaving, or else there is some feature that needs to be turned on that I'm not aware of. In any case, even if it was working the portchannel test still doesn't account for topologies where all the interfaces are already in portchannels, so we'd need to either add that in or just exclude Incremental Config from those topologies.