### PR TITLE
adding `sonic_link_flap` test to the repo

### DIFF
--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -257,8 +257,8 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap -e testbed_name={TESTBED_NAME}
 ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap -e testbed_name={TESTBED_NAME} -e seconds_to_run=10
 ```
-- Defaults to 10 minutes
-- Can specifiy a different time to run using the optional command line parameter
+- Defaults to 10 minutes but is configurable
+- Can specifiy a different length to run using the optional command line parameter
 
 ##### Syslog test
 ```

--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -252,6 +252,14 @@ ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_na
 ```
 - Requires switch connected to a VM set or PTF testbed
 
+##### Sonic Link Flap 
+```
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap -e testbed_name={TESTBED_NAME}
+ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap -e testbed_name={TESTBED_NAME} -e seconds_to_run=10
+```
+- Defaults to 10 minutes
+- Can specifiy a different time to run using the optional command line parameter
+
 ##### Syslog test
 ```
 ansible-playbook test_sonic.yml -i {INVENTORY} --limit {DUT_NAME} -e testcase_name=syslog -e testbed_name={TESTBED_NAME}

--- a/ansible/README.test.md
+++ b/ansible/README.test.md
@@ -258,7 +258,7 @@ ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap 
 ansible-playbook test_sonic.yml -i {INVENTORY} -e testcase_name=sonic_link_flap -e testbed_name={TESTBED_NAME} -e seconds_to_run=10
 ```
 - Defaults to 10 minutes but is configurable
-- Can specifiy a different length to run using the optional command line parameter
+- Can specify a different length to run using the optional command line parameter
 
 ##### Syslog test
 ```

--- a/ansible/roles/test/files/tools/loganalyzer/loganalyzer_sonic_link_flap_ignore.txt
+++ b/ansible/roles/test/files/tools/loganalyzer/loganalyzer_sonic_link_flap_ignore.txt
@@ -1,0 +1,2 @@
+r, ".* ERR ntpd.*routing socket reports: No buffer space available.*"
+r, ".*ERR dhcp_relay.*receive_packet failed on Ethernet.*: Network is down.*"

--- a/ansible/roles/test/tasks/run_script_with_log_analyzer.yml
+++ b/ansible/roles/test/tasks/run_script_with_log_analyzer.yml
@@ -1,0 +1,54 @@
+- name: Initialize some variables for loganalyzer
+  set_fact:
+    testname_unique: "{{ testname }}.{{ lookup('pipe','date +%Y-%m-%d-%H:%M:%S') }}"
+- set_fact:
+    test_out_dir: "{{ out_dir }}/{{ testname_unique }}"
+    loganalyzer_init: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+    loganalyzer_analyze: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+    match_file: loganalyzer_common_match.txt
+    ignore_file: loganalyzer_common_ignore.txt
+    summary_file: summary.loganalysis.{{ testname_unique }}.log
+    result_file: result.loganalysis.{{ testname_unique }}.log
+
+- block:
+    - name: Initialize loganalizer. Put start marker to log file.
+      include: roles/test/files/tools/loganalyzer/loganalyzer_init.yml
+
+    - name: Run script {{ script_to_run }}
+      script: "{{ script_to_run }}"
+      become: yes
+
+    - name: Use loganalyzer to check for the error messages {{ testname }} / {{ script_to_run }}.
+      include: roles/test/files/tools/loganalyzer/loganalyzer_analyze.yml
+
+    - name: Read loganalyzer summary file.
+      shell: cat "{{ test_out_dir }}/{{ summary_file }}"
+      register: log_summary
+
+    - name: Print loganalyzer summary file.
+      debug:
+        var: log_summary.stdout_lines
+
+    - name: Get the total number of expected messages.
+      shell: grep "TOTAL EXPECTED" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL EXPECTED MATCHES:[[:space:]]*//p"
+      register: expects_found
+      when: errors_expected == true
+
+    - name: Check that expected error messages are found (negative tests only).
+      fail: msg="Expected error messages are not found while running {{ testname }} / {{ script_to_run }}"
+      when: errors_expected == true and expects_found.stdout == "0"
+
+    - name: Get the total number of error messages.
+      shell: grep "TOTAL MATCHES" "{{ test_out_dir }}/{{ summary_file }}" | sed -n "s/TOTAL MATCHES:[[:space:]]*//p"
+      register: errors_found
+
+    - name: Check the number of error messages (positive tests only).
+      fail: msg="{{ errors_found.stdout }} errors found while running {{ testname }} / {{ script_to_run }}."
+      when: errors_expected == false and errors_found.stdout != "0"
+
+    - name: Copy test data to host.
+      fetch: src={{ test_out_dir }}/{{ item }} dest=failed-test-data/{{ testname_unique }}/{{ item }}
+      with_items:
+          - "{{ summary_file }}"
+          - "{{ result_file }}"
+      when: (errors_expected == true and expects_found.stdout == "0") or (errors_expected == false and errors_found.stdout != "0")

--- a/ansible/roles/test/tasks/sonic_link_flap.yml
+++ b/ansible/roles/test/tasks/sonic_link_flap.yml
@@ -1,0 +1,85 @@
+- block:
+  - name: set initial values if it's not set from commandline
+    set_fact:
+      seconds_to_run: 600 
+    when: seconds_to_run is not defined
+
+  - name: Get a list of active Ethernet interface names
+    set_fact:
+      test_interfaces: "{{ test_interfaces|default([]) }} + ['{{ item.device }}']"
+    when: item.active == True and "Ethernet" in item.device
+    with_items: "{{ ansible_interface_facts.values() }}"
+
+  - name: verify we have an active interface
+    assert:
+      that:
+        - test_interfaces is defined
+        - (test_interfaces | length) >= 1
+      msg: This test requires at least one active interface
+
+  - name: pick a test interface
+    set_fact:
+      test_interface: "{{ test_interfaces[0] }}"
+
+  - name: pull CPU utilization via shell
+    # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grap the CPU line from the second,
+    # subtract 100% - idle, and round down to integer.
+    shell: top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf "%.0f",$1}'
+    register: shell_cpu_usage_before
+    become: yes
+
+  - name: get used memory info
+    shell: "show system-memory | grep Mem: | while read name total used everything_else; do echo $used; done"
+    register: used_memory_before
+
+  - name: pre test memory values
+    debug:
+      var: used_memory_before.stdout
+
+  - name: pre test cpu values
+    debug:
+      var: shell_cpu_usage_before.stdout
+
+  - name: "run linkflap script on interface {{ test_interface }} for {{ seconds_to_run }} seconds and verify no errors"
+    vars:
+      script_to_run: "sonic_link_flap/sonic_link_flap.sh {{ seconds_to_run }} {{ test_interface }}"
+      testname: sonic_link_flap
+      out_dir: /tmp
+      run_dir: /tmp
+      errors_expected: false
+      ignore_file: "loganalyzer_sonic_link_flap_ignore.txt"
+    include: roles/test/tasks/run_script_with_log_analyzer.yml
+
+  - name: wait 30 seconds for the cpu to calm down
+    pause:
+      seconds: 30
+
+  - name: pull CPU utilization via shell
+    # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grap the CPU line from the second,
+    # subtract 100% - idle, and round down to integer.
+    shell: top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf "%.0f",$1}'
+    register: shell_cpu_usage_after
+    become: yes
+
+  - name: get used memory info before
+    shell: "show system-memory | grep Mem: | while read name total used everything_else; do echo $used; done"
+    register: used_memory_after
+
+  - name: post test memory values
+    debug:
+      var: used_memory_after.stdout
+
+  - name: post test cpu values
+    debug:
+      var: shell_cpu_usage_after.stdout
+
+  # If the CPU has 10% more utilization 30 seconds after the test is done, should fail
+  - name: verify cpu usage is not significantly higher than it was before it started
+    assert:
+      that: ({{shell_cpu_usage_after.stdout}} - {{shell_cpu_usage_before.stdout}}) < 10
+
+  # Make sure the memory usage doesn't go up too much
+  - name: verify memory usage is not significantly higher than it was before it started
+    assert:
+      that: ({{used_memory_after.stdout}} - {{used_memory_before.stdout}}) < 10
+

--- a/ansible/roles/test/tasks/sonic_link_flap.yml
+++ b/ansible/roles/test/tasks/sonic_link_flap.yml
@@ -22,7 +22,7 @@
       test_interface: "{{ test_interfaces[0] }}"
 
   - name: pull CPU utilization via shell
-    # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grap the CPU line from the second,
+    # Explanation: Run top command with 2 iterations, 5sec delay. Discard the first iteration, then grab the CPU line from the second,
     # subtract 100% - idle, and round down to integer.
     shell: top -bn2 -d5 | awk '/^top -/ { p=!p } { if (!p) print }' | awk '/Cpu/ { cpu = 100 - $8 };END   { print cpu }' | awk '{printf "%.0f",$1}'
     register: shell_cpu_usage_before

--- a/ansible/roles/test/tasks/sonic_link_flap/sonic_link_flap.sh
+++ b/ansible/roles/test/tasks/sonic_link_flap/sonic_link_flap.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# Script to bounce interfaces from the commandline repeatedly
+# $1 is the number of seconds to run the test
+# $2 is the interface to use
+
+end=$((SECONDS+$1))
+
+while [ $SECONDS -lt $end ]
+  do
+    sudo config interface shutdown $2
+    sudo config interface startup $2 
+done

--- a/ansible/roles/test/vars/testcases.yml
+++ b/ansible/roles/test/vars/testcases.yml
@@ -225,6 +225,10 @@ testcases:
       filename: snmp.yml
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]
 
+    sonic_link_flap:
+      filename: sonic_link_flap.yml
+      topologies: [t0, t0-16, t0-56, t0-64, t0-116, t1]
+
     syslog:
       filename: syslog.yml
       topologies: [t0, t0-56, t0-64, t0-64-32, t0-116, t1, t1-lag, t1-64-lag, ptf32, ptf64]


### PR DESCRIPTION

[sonic_link_flap_t0_eight_output.log](https://github.com/IGNW/sonic-mgmt/files/3596511/sonic_link_flap_t0_eight_output.log)
[sonic_link_flap_t1_eight_output.log](https://github.com/IGNW/sonic-mgmt/files/3596512/sonic_link_flap_t1_eight_output.log)


### Description of PR

Summary:
A test to shut down and bring up an interface on the DUT as fast as possible for 10 minutes

### Type of change

- [] Bug fix
- [] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### How did you do it?
Created a shell script that is run on the DUT that will run for however long you tell it to.  

The script runs the command to shut down and enable an active interface.

#### How did you verify/test it?
Used the log analyizer and some linux commands to verify the device wasn't in a race condition and no additional errors occured in the syslog files.

Ran the test on the t0-8 and t1-8 topology

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?
Should work on any t0 or t1 based test.

### Documentation 
Added information to the README.test.md file